### PR TITLE
odstranění duplikátu se špatným typem

### DIFF
--- a/content/d-sgov/d-sgov-sbírka/d-sgov-sbírka-model.ttl
+++ b/content/d-sgov/d-sgov-sbírka/d-sgov-sbírka-model.ttl
@@ -162,10 +162,6 @@ d-sgov-sbírka-pojem:má-předka a z-sgov-pojem:typ-vztahu;
     ];
   rdfs:subPropertyOf z-sgov-pojem:vztah .
 
-d-sgov-sbírka-pojem:označení-fragmentu-znění-právního-aktu a z-sgov-pojem:typ-vlastnosti;
-  rdfs:subClassOf z-sgov-pojem:vlastnost;
-  rdfs:subPropertyOf z-sgov-pojem:vlastnost .
-
 d-sgov-sbírka-pojem:má-komentář-fragmentu a z-sgov-pojem:typ-vztahu;
   rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
       owl:allValuesFrom d-sgov-sbírka-pojem:komentář-fragmentu;


### PR DESCRIPTION
:označení-fragmentu-znění-právního-aktu se v datech vyskytovalo dvakrát, jednou jako Kind a jednou jako Trope type.