### PR TITLE
Publishing workspace #283 (https://slovník.gov.cz/datový/pracovní-prostor/pojem/metadatový-kontext/instance1504121514)

### DIFF
--- a/content/d-sgov/d-sgov-číselníky/d-sgov-číselníky-glosář.ttl
+++ b/content/d-sgov/d-sgov-číselníky/d-sgov-číselníky-glosář.ttl
@@ -24,10 +24,52 @@ d-sgov-číselníky:glosář a a-popis-dat-pojem:glosář, owl:Ontology, skos:Co
     d-sgov-číselníky-pojem:popis-položky-číselníku, d-sgov-číselníky-pojem:zkrácený-název-položky-číselníku,
     d-sgov-číselníky-pojem:číselník .
 
+d-sgov-číselníky-pojem:eviduje-položku-číselníku a skos:Concept;
+  skos:altLabel "eviduje"@cs;
+  skos:inScheme d-sgov-číselníky:glosář;
+  skos:prefLabel "eviduje položku číselníku"@cs .
+
+d-sgov-číselníky-pojem:číselník a skos:Concept;
+  skos:inScheme d-sgov-číselníky:glosář;
+  skos:prefLabel "Číselník"@cs .
+
+d-sgov-číselníky-pojem:akronym-číselníku a skos:Concept;
+  skos:altLabel "akronym"@cs;
+  skos:definition "Zkratka číselníku používaná i jako jeho identifikátor."@cs;
+  skos:inScheme d-sgov-číselníky:glosář;
+  skos:prefLabel "akronym číselníku"@cs .
+
+d-sgov-číselníky-pojem:definice-číselníku a skos:Concept;
+  skos:altLabel "definice"@cs;
+  skos:definition "Delší text přesně definující číselník a položky, které eviduje."@cs;
+  skos:inScheme d-sgov-číselníky:glosář;
+  skos:prefLabel "definice číselníku"@cs .
+
+d-sgov-číselníky-pojem:má-administrativní-platnost-číselníku a skos:Concept;
+  skos:altLabel "platnost"@cs;
+  skos:definition "Přiřazuje číselníku časový interval, ve kterém je platný. Platnost určuje, v jakém časovém období byl, je nebo bude číselník platný. Pro snazší strojové zpracování se doporučuje nespoléhat na to, že uživatel aplikuje platnost číselníku i na jednotlivé položky. Je doporučeno platnost položek uvést přímo pro jednotlivé položky."@cs;
+  skos:inScheme d-sgov-číselníky:glosář;
+  skos:prefLabel "má administrativní platnost číselníku"@cs .
+
+d-sgov-číselníky-pojem:název-číselníku a skos:Concept;
+  skos:altLabel "název"@cs;
+  skos:inScheme d-sgov-číselníky:glosář;
+  skos:prefLabel "název číselníku"@cs .
+
 d-sgov-číselníky-pojem:položka-číselníku a skos:Concept;
   skos:altLabel "Položka"@cs, "položka"@cs;
   skos:inScheme d-sgov-číselníky:glosář;
   skos:prefLabel "Položka číselníku"@cs .
+
+d-sgov-číselníky-pojem:kód-položky-číselníku a skos:Concept;
+  skos:altLabel "kód"@cs;
+  skos:inScheme d-sgov-číselníky:glosář;
+  skos:prefLabel "kód položky číselníku"@cs .
+
+d-sgov-číselníky-pojem:zkrácený-název-položky-číselníku a skos:Concept;
+  skos:altLabel "zkrácený název"@cs;
+  skos:inScheme d-sgov-číselníky:glosář;
+  skos:prefLabel "zkrácený název položky číselníku"@cs .
 
 d-sgov-číselníky-pojem:název-položky-číselníku a skos:Concept;
   skos:altLabel "název"@cs;
@@ -38,47 +80,6 @@ d-sgov-číselníky-pojem:popis-položky-číselníku a skos:Concept;
   skos:altLabel "popis"@cs;
   skos:inScheme d-sgov-číselníky:glosář;
   skos:prefLabel "popis položky číselníku"@cs .
-
-d-sgov-číselníky-pojem:zkrácený-název-položky-číselníku a skos:Concept;
-  skos:altLabel "zkrácený název"@cs;
-  skos:inScheme d-sgov-číselníky:glosář;
-  skos:prefLabel "zkrácený název položky číselníku"@cs .
-
-d-sgov-číselníky-pojem:číselník a skos:Concept;
-  skos:inScheme d-sgov-číselníky:glosář;
-  skos:prefLabel "Číselník"@cs .
-
-d-sgov-číselníky-pojem:eviduje-položku-číselníku a skos:Concept;
-  skos:altLabel "eviduje"@cs;
-  skos:inScheme d-sgov-číselníky:glosář;
-  skos:prefLabel "eviduje položku číselníku"@cs .
-
-d-sgov-číselníky-pojem:kód-položky-číselníku a skos:Concept;
-  skos:altLabel "kód"@cs;
-  skos:inScheme d-sgov-číselníky:glosář;
-  skos:prefLabel "kód položky číselníku"@cs .
-
-d-sgov-číselníky-pojem:název-číselníku a skos:Concept;
-  skos:altLabel "název"@cs;
-  skos:inScheme d-sgov-číselníky:glosář;
-  skos:prefLabel "název číselníku"@cs .
-
-d-sgov-číselníky-pojem:akronym-číselníku a skos:Concept;
-  skos:altLabel "akronym"@cs;
-  skos:definition "Zkratka číselníku používaná i jako jeho identifikátor."@cs;
-  skos:inScheme d-sgov-číselníky:glosář;
-  skos:prefLabel "akronym číselníku"@cs .
-
-d-sgov-číselníky-pojem:definice-číselníku a skos:Concept;
-  skos:definition "Delší text přesně definující číselník a položky, které eviduje."@cs;
-  skos:inScheme d-sgov-číselníky:glosář;
-  skos:prefLabel "definice číselníku"@cs .
-
-d-sgov-číselníky-pojem:má-administrativní-platnost-číselníku a skos:Concept;
-  skos:altLabel "platnost"@cs;
-  skos:definition "Přiřazuje číselníku časový interval, ve kterém je platný. Platnost určuje, v jakém časovém období byl, je nebo bude číselník platný. Pro snazší strojové zpracování se doporučuje nespoléhat na to, že uživatel aplikuje platnost číselníku i na jednotlivé položky. Je doporučeno platnost položek uvést přímo pro jednotlivé položky."@cs;
-  skos:inScheme d-sgov-číselníky:glosář;
-  skos:prefLabel "má administrativní platnost číselníku"@cs .
 
 d-sgov-číselníky-pojem:pokrývá-oblast a skos:Concept;
   skos:definition "Specifikuje obecný pojem, který reprezentuje oblast nebo doménu, kterou číselník svými položkami pokrývá."@cs;

--- a/content/d-sgov/d-sgov-číselníky/d-sgov-číselníky-model.ttl
+++ b/content/d-sgov/d-sgov-číselníky/d-sgov-číselníky-model.ttl
@@ -20,18 +20,107 @@ d-sgov-číselníky:model a a-popis-dat-pojem:model, owl:Ontology;
   owl:imports d-sgov-číselníky:glosář;
   owl:versionIRI "https://slovník.gov.cz/datový/číselníky/model/verze/1.0.0" .
 
+d-sgov-číselníky-pojem:eviduje-položku-číselníku a z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf <https://slovník.gov.cz/veřejný-sektor/pojem/eviduje-položku-evidenčního-systému>,
+    [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom d-sgov-číselníky-pojem:číselník
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom d-sgov-číselníky-pojem:položka-číselníku
+    ], [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass d-sgov-číselníky-pojem:položka-číselníku;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:allValuesFrom d-sgov-číselníky-pojem:položka-číselníku;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass d-sgov-číselníky-pojem:číselník;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass d-sgov-číselníky-pojem:položka-číselníku;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass d-sgov-číselníky-pojem:číselník;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:allValuesFrom d-sgov-číselníky-pojem:číselník;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ] .
+
+d-sgov-číselníky-pojem:číselník a z-sgov-pojem:mixin, z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf <https://slovník.gov.cz/veřejný-sektor/pojem/evidenční-systém> .
+
+d-sgov-číselníky-pojem:akronym-číselníku a z-sgov-pojem:typ-vlastnosti;
+  rdfs:subClassOf [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:je-vlastností;
+      owl:someValuesFrom d-sgov-číselníky-pojem:číselník
+    ], [ a owl:Restriction;
+      owl:allValuesFrom d-sgov-číselníky-pojem:číselník;
+      owl:onProperty z-sgov-pojem:je-vlastností
+    ] .
+
+d-sgov-číselníky-pojem:definice-číselníku a z-sgov-pojem:typ-vlastnosti;
+  rdfs:subClassOf [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:je-vlastností;
+      owl:someValuesFrom d-sgov-číselníky-pojem:číselník
+    ], [ a owl:Restriction;
+      owl:allValuesFrom d-sgov-číselníky-pojem:číselník;
+      owl:onProperty z-sgov-pojem:je-vlastností
+    ] .
+
+d-sgov-číselníky-pojem:má-administrativní-platnost-číselníku a z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf <https://slovník.gov.cz/veřejný-sektor/pojem/má-platnost>, [ a owl:Restriction;
+      owl:allValuesFrom d-sgov-číselníky-pojem:číselník;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass d-sgov-číselníky-pojem:číselník;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom d-sgov-číselníky-pojem:číselník
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass d-sgov-číselníky-pojem:číselník;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ] .
+
+d-sgov-číselníky-pojem:název-číselníku a z-sgov-pojem:typ-vlastnosti;
+  rdfs:subClassOf [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass d-sgov-číselníky-pojem:číselník;
+      owl:onProperty z-sgov-pojem:je-vlastností
+    ], [ a owl:Restriction;
+      owl:allValuesFrom d-sgov-číselníky-pojem:číselník;
+      owl:onProperty z-sgov-pojem:je-vlastností
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass d-sgov-číselníky-pojem:číselník;
+      owl:onProperty z-sgov-pojem:je-vlastností
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:je-vlastností;
+      owl:someValuesFrom d-sgov-číselníky-pojem:číselník
+    ] .
+
 d-sgov-číselníky-pojem:položka-číselníku a z-sgov-pojem:mixin-rolí, z-sgov-pojem:typ-objektu;
   rdfs:subClassOf <https://slovník.gov.cz/veřejný-sektor/pojem/položka-evidenčního-systému> .
 
-d-sgov-číselníky-pojem:číselník a z-sgov-pojem:mixin, z-sgov-pojem:typ-objektu ;
-  rdfs:subClassOf <https://slovník.gov.cz/veřejný-sektor/pojem/evidenční-systém> .
-
-d-sgov-číselníky-pojem:název-položky-číselníku a z-sgov-pojem:typ-vlastnosti;
+d-sgov-číselníky-pojem:kód-položky-číselníku a z-sgov-pojem:typ-vlastnosti;
   rdfs:subClassOf [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass d-sgov-číselníky-pojem:položka-číselníku;
+      owl:allValuesFrom d-sgov-číselníky-pojem:položka-číselníku;
       owl:onProperty z-sgov-pojem:je-vlastností
     ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:je-vlastností;
+      owl:someValuesFrom d-sgov-číselníky-pojem:položka-číselníku
+    ] .
+
+d-sgov-číselníky-pojem:zkrácený-název-položky-číselníku a z-sgov-pojem:typ-vlastnosti;
+  rdfs:subClassOf [ a owl:Restriction;
       owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
       owl:onClass d-sgov-číselníky-pojem:položka-číselníku;
       owl:onProperty z-sgov-pojem:je-vlastností
@@ -39,8 +128,29 @@ d-sgov-číselníky-pojem:název-položky-číselníku a z-sgov-pojem:typ-vlastn
       owl:allValuesFrom d-sgov-číselníky-pojem:položka-číselníku;
       owl:onProperty z-sgov-pojem:je-vlastností
     ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass d-sgov-číselníky-pojem:položka-číselníku;
+      owl:onProperty z-sgov-pojem:je-vlastností
+    ], [ a owl:Restriction;
       owl:onProperty z-sgov-pojem:je-vlastností;
       owl:someValuesFrom d-sgov-číselníky-pojem:položka-číselníku
+    ] .
+
+d-sgov-číselníky-pojem:název-položky-číselníku a z-sgov-pojem:typ-vlastnosti;
+  rdfs:subClassOf [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass d-sgov-číselníky-pojem:položka-číselníku;
+      owl:onProperty z-sgov-pojem:je-vlastností
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:je-vlastností;
+      owl:someValuesFrom d-sgov-číselníky-pojem:položka-číselníku
+    ], [ a owl:Restriction;
+      owl:allValuesFrom d-sgov-číselníky-pojem:položka-číselníku;
+      owl:onProperty z-sgov-pojem:je-vlastností
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass d-sgov-číselníky-pojem:položka-číselníku;
+      owl:onProperty z-sgov-pojem:je-vlastností
     ] .
 
 d-sgov-číselníky-pojem:popis-položky-číselníku a z-sgov-pojem:typ-vlastnosti;
@@ -53,151 +163,40 @@ d-sgov-číselníky-pojem:popis-položky-číselníku a z-sgov-pojem:typ-vlastno
       owl:onClass d-sgov-číselníky-pojem:položka-číselníku;
       owl:onProperty z-sgov-pojem:je-vlastností
     ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:je-vlastností;
-      owl:someValuesFrom d-sgov-číselníky-pojem:položka-číselníku
-    ], [ a owl:Restriction;
-      owl:allValuesFrom d-sgov-číselníky-pojem:položka-číselníku;
-      owl:onProperty z-sgov-pojem:je-vlastností
-    ] .
-
-d-sgov-číselníky-pojem:zkrácený-název-položky-číselníku a z-sgov-pojem:typ-vlastnosti;
-  rdfs:subClassOf [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass d-sgov-číselníky-pojem:položka-číselníku;
-      owl:onProperty z-sgov-pojem:je-vlastností
-    ], [ a owl:Restriction;
       owl:allValuesFrom d-sgov-číselníky-pojem:položka-číselníku;
       owl:onProperty z-sgov-pojem:je-vlastností
     ], [ a owl:Restriction;
       owl:onProperty z-sgov-pojem:je-vlastností;
       owl:someValuesFrom d-sgov-číselníky-pojem:položka-číselníku
-    ], [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass d-sgov-číselníky-pojem:položka-číselníku;
-      owl:onProperty z-sgov-pojem:je-vlastností
-    ] .
-
-d-sgov-číselníky-pojem:eviduje-položku-číselníku a z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf <https://slovník.gov.cz/veřejný-sektor/pojem/eviduje-položku-evidenčního-systému>,
-    [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass d-sgov-číselníky-pojem:číselník;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass d-sgov-číselníky-pojem:číselník;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass d-sgov-číselníky-pojem:položka-číselníku;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass d-sgov-číselníky-pojem:položka-číselníku;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
-      owl:someValuesFrom d-sgov-číselníky-pojem:číselník
-    ], [ a owl:Restriction;
-      owl:allValuesFrom d-sgov-číselníky-pojem:číselník;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom d-sgov-číselníky-pojem:položka-číselníku
-    ], [ a owl:Restriction;
-      owl:allValuesFrom d-sgov-číselníky-pojem:položka-číselníku;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ] .
-
-d-sgov-číselníky-pojem:kód-položky-číselníku a z-sgov-pojem:typ-vlastnosti;
-  rdfs:subClassOf [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:je-vlastností;
-      owl:someValuesFrom d-sgov-číselníky-pojem:položka-číselníku
-    ], [ a owl:Restriction;
-      owl:allValuesFrom d-sgov-číselníky-pojem:položka-číselníku;
-      owl:onProperty z-sgov-pojem:je-vlastností
-    ] .
-
-d-sgov-číselníky-pojem:název-číselníku a z-sgov-pojem:typ-vlastnosti;
-  rdfs:subClassOf [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass d-sgov-číselníky-pojem:číselník;
-      owl:onProperty z-sgov-pojem:je-vlastností
-    ], [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass d-sgov-číselníky-pojem:číselník;
-      owl:onProperty z-sgov-pojem:je-vlastností
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:je-vlastností;
-      owl:someValuesFrom d-sgov-číselníky-pojem:číselník
-    ], [ a owl:Restriction;
-      owl:allValuesFrom d-sgov-číselníky-pojem:číselník;
-      owl:onProperty z-sgov-pojem:je-vlastností
-    ] .
-
-d-sgov-číselníky-pojem:akronym-číselníku a z-sgov-pojem:typ-vlastnosti ;
-  rdfs:subClassOf  [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:je-vlastností;
-      owl:someValuesFrom d-sgov-číselníky-pojem:číselník
-    ], [ a owl:Restriction;
-      owl:allValuesFrom d-sgov-číselníky-pojem:číselník;
-      owl:onProperty z-sgov-pojem:je-vlastností
-    ] .
-
-
-d-sgov-číselníky-pojem:definice-číselníku a z-sgov-pojem:typ-vlastnosti ;
-  rdfs:subClassOf  [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:je-vlastností;
-      owl:someValuesFrom d-sgov-číselníky-pojem:číselník
-    ], [ a owl:Restriction;
-      owl:allValuesFrom d-sgov-číselníky-pojem:číselník;
-      owl:onProperty z-sgov-pojem:je-vlastností
-    ] .
-
-d-sgov-číselníky-pojem:má-administrativní-platnost-číselníku a z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf <https://slovník.gov.cz/veřejný-sektor/pojem/má-platnost>, [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass d-sgov-číselníky-pojem:číselník;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass d-sgov-číselníky-pojem:číselník;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
-      owl:someValuesFrom d-sgov-číselníky-pojem:číselník
-    ], [ a owl:Restriction;
-      owl:allValuesFrom d-sgov-číselníky-pojem:číselník;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
     ] .
 
 d-sgov-číselníky-pojem:pokrývá-oblast a z-sgov-pojem:typ-vztahu;
   rdfs:subClassOf [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass d-sgov-číselníky-pojem:číselník;
+      owl:allValuesFrom d-sgov-číselníky-pojem:číselník;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass d-sgov-číselníky-pojem:číselník;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass <https://slovník.gov.cz/veřejný-sektor/pojem/položka-evidenčního-systému>;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass <https://slovník.gov.cz/veřejný-sektor/pojem/položka-evidenčního-systému>;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
     ], [ a owl:Restriction;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
       owl:someValuesFrom d-sgov-číselníky-pojem:číselník
     ], [ a owl:Restriction;
-      owl:allValuesFrom d-sgov-číselníky-pojem:číselník;
+      owl:allValuesFrom <https://slovník.gov.cz/veřejný-sektor/pojem/položka-evidenčního-systému>;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass d-sgov-číselníky-pojem:číselník;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass <https://slovník.gov.cz/veřejný-sektor/pojem/položka-evidenčního-systému>;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass d-sgov-číselníky-pojem:číselník;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
     ], [ a owl:Restriction;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
       owl:someValuesFrom <https://slovník.gov.cz/veřejný-sektor/pojem/položka-evidenčního-systému>
     ], [ a owl:Restriction;
-      owl:allValuesFrom <https://slovník.gov.cz/veřejný-sektor/pojem/položka-evidenčního-systému>;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass <https://slovník.gov.cz/veřejný-sektor/pojem/položka-evidenčního-systému>;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
     ] .

--- a/content/g-sgov/g-sgov-číselníky/g-sgov-číselníky-glosář.ttl
+++ b/content/g-sgov/g-sgov-číselníky/g-sgov-číselníky-glosář.ttl
@@ -18,150 +18,139 @@ g-sgov-číselníky:glosář a a-popis-dat-pojem:glosář, owl:Ontology, skos:Co
   vann:preferredNamespaceUri "https://slovník.gov.cz/generický/číselníky/pojem/";
   owl:versionIRI <https://slovník.gov.cz/generický/číselníky/glosář/verze/0.0.1>;
   skos:hasTopConcept g-sgov-číselníky-pojem:míra-specifikace, g-sgov-číselníky-pojem:obor-frascati,
-    g-sgov-číselníky-pojem:obor-isvav,
-    g-sgov-číselníky-pojem:typ-pracovního-místa-ve-vědě-a-výzkumu, g-sgov-číselníky-pojem:číselník .
+    g-sgov-číselníky-pojem:obor-isvav, g-sgov-číselníky-pojem:typ-pracovního-místa-ve-vědě-a-výzkumu .
 
 g-sgov-číselníky-pojem:měna a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
+  skos:broader z-sgov-pojem:typ-objektu;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Měna"@cs;
   skos:scopeNote "Měna dle evropského číselníku měn z EU Vocabularies."@cs .
 
 g-sgov-číselníky-pojem:jednotka a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
+  skos:broader z-sgov-pojem:typ-objektu;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Jednotka"@cs;
   skos:scopeNote "Jednotka dle číselníku UN/CEFACT Common Codes."@cs .
 
 g-sgov-číselníky-pojem:stát a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
+  skos:broader z-sgov-pojem:typ-objektu;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Stát"@cs;
   skos:scopeNote "Stát dle evropského číselníku zemí z EU Vocabularies."@cs .
 
 g-sgov-číselníky-pojem:pohlaví a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
+  skos:broader z-sgov-pojem:typ-objektu;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Pohlaví"@cs;
   skos:scopeNote "Jazyk dle Evropského číselníku jazyků http://publications.europa.eu/resource/dataset/language."@cs .
 
 g-sgov-číselníky-pojem:typ-události a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
+  skos:broader z-sgov-pojem:typ-objektu;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Typ události"@cs;
   skos:scopeNote "Reprezentuje hodnoty z číselníku pro typy událostí."@cs .
 
 g-sgov-číselníky-pojem:téma-události a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
+  skos:broader z-sgov-pojem:typ-objektu;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Téma události"@cs;
   skos:scopeNote "Reprezentuje hodnoty z číselníku pro témata událostí."@cs .
 
 g-sgov-číselníky-pojem:typ-turistického-cíle a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
+  skos:broader z-sgov-pojem:typ-objektu;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Typ turistického cíle"@cs;
   skos:scopeNote "Reprezentuje hodnoty z číselníku pro typy turistických cílů."@cs .
 
 g-sgov-číselníky-pojem:jazyk a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
+  skos:broader z-sgov-pojem:typ-objektu;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Jazyk"@cs;
   skos:scopeNote "Jazyk dle Evropského číselníku jazyků http://publications.europa.eu/resource/dataset/language."@cs .
 
 g-sgov-číselníky-pojem:typ-sportoviště a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
+  skos:broader z-sgov-pojem:typ-objektu;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Typ sportoviště"@cs;
   skos:scopeNote "Reprezentuje hodnoty z číselníku pro typy sportovišt."@cs .
 
 g-sgov-číselníky-pojem:sport a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
+  skos:broader z-sgov-pojem:typ-objektu;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Sport"@cs;
   skos:scopeNote "Reprezentuje hodnoty z číselníku pro sporty."@cs .
 
 g-sgov-číselníky-pojem:obor-isvav a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník;
   skos:definition "Obor vědy a výzkumu z Informačního systému výzkumu a vývoje (ISVaV)"@cs;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Obor ISVaV"@cs;
   skos:scopeNote ""@cs .
 
 g-sgov-číselníky-pojem:obor-frascati a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník;
   skos:definition "Obor dle Frascati manuálu (FORD)."@cs;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Obor Frascati"@cs;
   skos:scopeNote ""@cs .
 
 g-sgov-číselníky-pojem:typ-pracovního-místa-ve-vědě-a-výzkumu a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník;
   skos:definition "Typ pracovního místa, které spadá do domény vědy a výzkumu. Patří sem i pracovní místa na vysokých školách, včetně lektorských pozic."@cs;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Typ pracovního místa ve vědě a výzkumu"@cs;
   skos:scopeNote ""@cs .
 
 g-sgov-číselníky-pojem:typ-pracovního-vztahu a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
+  skos:broader z-sgov-pojem:typ-objektu;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Typ pracovního vztahu"@cs .
 
 g-sgov-číselníky-pojem:stupeň-přístupnosti a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
+  skos:broader z-sgov-pojem:typ-objektu;
   skos:definition "http://presbariery.cz/cz/mapovani-barierovosti/metodika"@cs;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Stupeň přístupnosti"@cs;
   skos:scopeNote "Říká, zda se jedná o objekt \"přístupný\", \"částečně přístupný\" nebo \"nepřístupný\". Stupeň přístupnosti lze určit nejlépe pomocí Metodiky kategorizace přístupnosti objektů, viz http://presbariery.cz/cz/mapovani-barierovosti/metodika."@cs .
 
-g-sgov-číselníky-pojem:číselník a skos:Concept;
-  skos:broader <https://slovník.gov.cz/veřejný-sektor/pojem/evidenční-systém>, z-sgov-pojem:poddruh,
-    z-sgov-pojem:typ-objektu;
-  skos:inScheme g-sgov-číselníky:glosář;
-  skos:prefLabel "Číselník"@cs .
-
 g-sgov-číselníky-pojem:míra-specifikace a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník;
   skos:definition "Míra specifikace tématu práce"@cs;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Míra specifikace"@cs;
   skos:scopeNote ""@cs .
 
 g-sgov-číselníky-pojem:frekvence a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
+  skos:broader z-sgov-pojem:typ-objektu;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Frekvence"@cs;
   skos:scopeNote "Frekvence určuje opakování. Např. čtrnáctidenní frekvence v kombinaci s časovým intervalem od 1.1.2020 do 31.12.2020 znamená \"každých čtrnáct dní v roce 2020\". Hodnoty této vlastnosti jsou z číselníku Frequency publikované jako číselník EU Vocabularies. V příkladu je uvedena čtrnáctidenní frekvence."@cs .
 
 g-sgov-číselníky-pojem:jiná-časová-specifikace a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
+  skos:broader z-sgov-pojem:typ-objektu;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Jiná časová specifikace"@cs;
   skos:scopeNote "Jiná časová specifikace se použije pro situace jako \"v případě dobrého/špatného počasí\" apod. Hodnoty této vlastnosti jsou z Číselníku pro jinou časovou specifikaci publikovaného jako číselník v Národním katalogu otevřených dat. V příkladu je uvedena prezentace \"dobré počasí\". Tuto vlastnost lze také využít pro vyjádření opakování dané aktivity v konkrétním případě."@cs .
 
 g-sgov-číselníky-pojem:akademický-obor a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
+  skos:broader z-sgov-pojem:typ-objektu;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Akademický obor"@cs .
 
+g-sgov-číselníky-pojem:typ-pracoviště a skos:Concept;
+  skos:broader z-sgov-pojem:typ-objektu;
+  skos:inScheme g-sgov-číselníky:glosář;
+  skos:prefLabel "Typ pracoviště"@cs .
+
 g-sgov-číselníky-pojem:den-v-týdnu a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
+  skos:broader z-sgov-pojem:typ-objektu;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Den v týdnu"@cs;
   skos:scopeNote "Denv týdnu"@cs .
 
 g-sgov-číselníky-pojem:časové-období a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
+  skos:broader z-sgov-pojem:typ-objektu;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Časové období"@cs;
   skos:scopeNote "Časové období specifikuje například každý říjen. V kombinaci s časovým intervalem, např. od 1.1.2020 do 31.12.2021, můžeme specifikovat každý říjen v tomto intervalu - jsou dva. Hodnoty této vlastnosti jsou z číselníku Time period publikovaného jako číselník EU Vocabularies."@cs .
 
 g-sgov-číselníky-pojem:typ-média a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
+  skos:broader z-sgov-pojem:typ-objektu;
   skos:inScheme g-sgov-číselníky:glosář;
   skos:prefLabel "Typ média"@cs .
-
-g-sgov-číselníky-pojem:typ-pracoviště a skos:Concept;
-  skos:broader g-sgov-číselníky-pojem:číselník, z-sgov-pojem:typ-objektu;
-  skos:inScheme g-sgov-číselníky:glosář;
-  skos:prefLabel "Typ pracoviště"@cs .

--- a/content/g-sgov/g-sgov-číselníky/g-sgov-číselníky-model.ttl
+++ b/content/g-sgov/g-sgov-číselníky/g-sgov-číselníky-model.ttl
@@ -33,75 +33,75 @@ z-sgov-pojem:má-vztažený-prvek a owl:ObjectProperty;
   owl:inverseOf z-sgov-pojem:je-ve-vztahu .
 
 g-sgov-číselníky-pojem:měna a owl:Class, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf g-sgov-číselníky-pojem:číselník .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:jednotka a owl:Class, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf g-sgov-číselníky-pojem:číselník .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:stát a owl:Class, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf g-sgov-číselníky-pojem:číselník .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:pohlaví a owl:Class, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf g-sgov-číselníky-pojem:číselník .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:typ-události a owl:Class, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf g-sgov-číselníky-pojem:číselník .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:téma-události a owl:Class, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf g-sgov-číselníky-pojem:číselník .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:typ-turistického-cíle a owl:Class, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf g-sgov-číselníky-pojem:číselník .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:jazyk a owl:Class, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf g-sgov-číselníky-pojem:číselník .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:typ-sportoviště a owl:Class, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf g-sgov-číselníky-pojem:číselník .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:sport a owl:Class, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf g-sgov-číselníky-pojem:číselník .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:obor-isvav a <http://onto.fel.cvut.cz/ontologies/ufo/object-type>,
     z-sgov-pojem:typ-objektu;
-  dcterms:source <https://www.vyzkum.cz/FrontClanek.aspx?idsekce=1374> .
+  dcterms:source <https://www.vyzkum.cz/FrontClanek.aspx?idsekce=1374>;
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:obor-frascati a <http://onto.fel.cvut.cz/ontologies/ufo/object-type>,
     z-sgov-pojem:typ-objektu;
-  dcterms:source <https://www.vyzkum.cz/FrontClanek.aspx?idsekce=799796&ad=1&attid=847693> .
+  dcterms:source <https://www.vyzkum.cz/FrontClanek.aspx?idsekce=799796&ad=1&attid=847693>;
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:typ-pracovního-vztahu a owl:Class, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf g-sgov-číselníky-pojem:číselník .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:stupeň-přístupnosti a owl:Class, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf g-sgov-číselníky-pojem:číselník .
-
-g-sgov-číselníky-pojem:číselník a owl:Class, z-sgov-pojem:poddruh, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf <https://slovník.gov.cz/veřejný-sektor/pojem/evidenční-systém> .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:míra-specifikace a <http://onto.fel.cvut.cz/ontologies/ufo/object-type>,
-    z-sgov-pojem:typ-objektu .
+    z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:frekvence a owl:Class, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf g-sgov-číselníky-pojem:číselník .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:jiná-časová-specifikace a owl:Class, z-sgov-pojem:typ-objektu;
   dcterms:relation <https://data.mvcr.gov.cz/zdroj/datové-sady/číselníky/jiná-časová-specifikace>;
-  rdfs:subClassOf g-sgov-číselníky-pojem:číselník .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:akademický-obor a owl:Class, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf g-sgov-číselníky-pojem:číselník .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:typ-pracoviště a owl:Class, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf g-sgov-číselníky-pojem:číselník .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:den-v-týdnu a owl:Class, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf <https://slovník.gov.cz/generický/čas/pojem/den-v-týdnu>, g-sgov-číselníky-pojem:číselník .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník>, <https://slovník.gov.cz/generický/čas/pojem/den-v-týdnu> .
 
 g-sgov-číselníky-pojem:časové-období a owl:Class, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf g-sgov-číselníky-pojem:číselník .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 g-sgov-číselníky-pojem:typ-média a owl:Class, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf g-sgov-číselníky-pojem:číselník .
+  rdfs:subClassOf <https://slovník.gov.cz/datový/číselníky/pojem/číselník> .
 
 skos:prefLabel rdfs:subPropertyOf rdfs:label .

--- a/content/v-sgov/v-sgov-glosář.ttl
+++ b/content/v-sgov/v-sgov-glosář.ttl
@@ -28,10 +28,10 @@ v-sgov:glosář a a-popis-dat-pojem:glosář, owl:NamedIndividual, owl:Ontology,
     v-sgov-pojem:má-zdrojový-předpis, v-sgov-pojem:má-znění, v-sgov-pojem:má-čas-poslední-aktualizace,
     v-sgov-pojem:má-čas-vytvoření, v-sgov-pojem:má-část-právního-předpisu, v-sgov-pojem:má-část-znění,
     v-sgov-pojem:novela-právního-předpisu, v-sgov-pojem:novelizuje, v-sgov-pojem:název-právního-předpisu,
-    v-sgov-pojem:objekt-práva, v-sgov-pojem:organizace, v-sgov-pojem:pokrývá-oblast,
-    v-sgov-pojem:položka, v-sgov-pojem:položka-evidenčního-systému, v-sgov-pojem:popisuje,
-    v-sgov-pojem:popsaný-prvek, v-sgov-pojem:povinnost, v-sgov-pojem:prostorový-objekt,
-    v-sgov-pojem:právní-vztah, v-sgov-pojem:právo, v-sgov-pojem:příjmení, v-sgov-pojem:subjekt-práva,
+    v-sgov-pojem:objekt-práva, v-sgov-pojem:organizace, v-sgov-pojem:pokrývá-oblast, v-sgov-pojem:položka,
+    v-sgov-pojem:položka-evidenčního-systému, v-sgov-pojem:popisuje, v-sgov-pojem:popsaný-prvek,
+    v-sgov-pojem:povinnost, v-sgov-pojem:prostorový-objekt, v-sgov-pojem:právní-vztah,
+    v-sgov-pojem:právo, v-sgov-pojem:příjmení, v-sgov-pojem:spravuje, v-sgov-pojem:subjekt-práva,
     v-sgov-pojem:typ-evidenčního-systému, v-sgov-pojem:typ-znalostní-struktury-dle-úrovně,
     v-sgov-pojem:vyhlášené-znění-právního-předpisu, v-sgov-pojem:výkon-svrchované-moci,
     v-sgov-pojem:znění-právního-předpisu, v-sgov-pojem:způsobilost-k-protiprávnímu-jednání,
@@ -44,13 +44,6 @@ v-sgov-pojem:fyzická-osoba a skos:Concept;
   skos:inScheme v-sgov:glosář;
   skos:prefLabel "Fyzická osoba"@cs, "Natural Person"@en .
 
-v-sgov-pojem:subjekt-práva a skos:Concept;
-  skos:broader z-sgov-pojem:agent, z-sgov-pojem:mixin-rolí, z-sgov-pojem:typ-objektu;
-  skos:definition "Legal Subject is a person participating in one or more legal relationships."@en,
-    "Subjekt práva je osoba,  která se účastní právních vztahů."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Legal Subject"@en, "Subjekt práva"@cs .
-
 v-sgov-pojem:člověk a skos:Concept;
   skos:broader z-sgov-pojem:agent, z-sgov-pojem:druh, z-sgov-pojem:typ-objektu;
   skos:definition "Human is the genus that encompasses the species Homo sapiens."@en,
@@ -58,11 +51,97 @@ v-sgov-pojem:člověk a skos:Concept;
   skos:inScheme v-sgov:glosář;
   skos:prefLabel "Human"@en, "Člověk"@cs .
 
-v-sgov-pojem:evidenční-systém a skos:Concept;
-  skos:broader v-sgov-pojem:datová-sada, z-sgov-pojem:poddruh, z-sgov-pojem:typ-objektu;
-  skos:definition "Evidence System is a data set which records endurants."@en, "Evidenční systém je datová sada, která eviduje proměnné prvky."@cs;
+v-sgov-pojem:subjekt-práva a skos:Concept;
+  skos:broader z-sgov-pojem:agent, z-sgov-pojem:mixin-rolí, z-sgov-pojem:typ-objektu;
+  skos:definition "Legal Subject is a person participating in one or more legal relationships."@en,
+    "Subjekt práva je osoba,  která se účastní právních vztahů."@cs;
   skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Evidence System"@en, "Evidenční systém"@cs .
+  skos:prefLabel "Legal Subject"@en, "Subjekt práva"@cs .
+
+v-sgov-pojem:akronym-číselníku a skos:Concept;
+  skos:altLabel "akronym"@cs;
+  skos:definition "Zkratka číselníku používaná i jako jeho identifikátor."@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "akronym číselníku"@cs .
+
+v-sgov-pojem:definice-číselníku a skos:Concept;
+  skos:altLabel "definice"@cs;
+  skos:definition "Delší text přesně definující číselník a položky, které eviduje."@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "definice číselníku"@cs .
+
+v-sgov-pojem:digitální-objekt a skos:Concept;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Digitální objekt"@cs .
+
+v-sgov-pojem:kód-číselníku a skos:Concept;
+  skos:altLabel "kód"@cs;
+  skos:definition "Kód číselníku identifikuje číselník."@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "kód číselníku"@cs .
+
+v-sgov-pojem:má-administrativní-platnost-položky a skos:Concept;
+  skos:altLabel "má platnost"@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "má administrativní platnost položky"@cs .
+
+v-sgov-pojem:má-administrativní-platnost-číselníku a skos:Concept;
+  skos:altLabel "má platnost"@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "má administrativní platnost číselníku"@cs .
+
+v-sgov-pojem:má-platnost a skos:Concept;
+  skos:broader z-sgov-pojem:typ-vztahu, z-sgov-pojem:vztah;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "má platnost"@cs .
+
+v-sgov-pojem:pokrývá-oblast a skos:Concept;
+  skos:definition "Vymezuje významovou oblast (doménu), kterou pokrývá evidenční systém a v něm evidované položky."@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "pokrývá oblast"@cs .
+
+v-sgov-pojem:položka-evidenčního-systému a skos:Concept;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Položka evidenčního systému"@cs .
+
+v-sgov-pojem:položka a skos:Concept;
+  skos:definition "Položka je proměnný prvek evidovaný v datové sadě. Položka má vlastní identitu."@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Položka"@cs .
+
+v-sgov-pojem:eviduje-položku-evidenčního-systému a skos:Concept;
+  skos:altLabel "eviduje"@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "eviduje položku evidenčního systému"@cs, "records evidence system record"@en .
+
+v-sgov-pojem:eviduje a skos:Concept;
+  skos:broader z-sgov-pojem:typ-vztahu, z-sgov-pojem:vztah;
+  skos:definition "'eviduje' označuje relator spojující evidenční systém s evidovaným endurantem."@cs,
+    "'records' denotes a relator connecting an evidence system with an endurant."@en;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "eviduje"@cs, "records"@en .
+
+v-sgov-pojem:má-přílohu a skos:Concept;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "has attachment"@en, "má přílohu"@cs .
+
+v-sgov-pojem:má-čas-poslední-aktualizace a skos:Concept;
+  skos:altLabel "aktualizován"@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "has last update time"@en, "má čas poslední aktualizace"@cs .
+
+v-sgov-pojem:má-čas-vytvoření a skos:Concept;
+  skos:altLabel "vytvořen"@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "has creation time"@en, "má čas vytvoření"@cs .
+
+v-sgov-pojem:popisuje a skos:Concept;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "describes"@en, "popisuje"@cs .
+
+v-sgov-pojem:popsaný-prvek a skos:Concept;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Popsaný prvek"@cs, "described entity"@en .
 
 v-sgov-pojem:hlava a skos:Concept;
   skos:broader v-sgov-pojem:část-právního-předpisu-ze-sbírky-zákonů, z-sgov-pojem:druh,
@@ -72,6 +151,10 @@ v-sgov-pojem:hlava a skos:Concept;
   skos:inScheme v-sgov:glosář;
   skos:prefLabel "Chapter"@en, "Hlava"@cs .
 
+v-sgov-pojem:část-znění-právního-předpisu a skos:Concept;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Část znění právního předpisu"@cs .
+
 v-sgov-pojem:část-právního-předpisu-ze-sbírky-zákonů a skos:Concept;
   skos:broader v-sgov-pojem:kontextový-dokument, z-sgov-pojem:kategorie, z-sgov-pojem:typ-objektu;
   skos:definition "Part of Legal Norm from the Collection of Laws of the Czech Republic denotes an identifiable part of a Legal Norm from the Collection of Laws of the Czech Republic"@en,
@@ -80,11 +163,18 @@ v-sgov-pojem:část-právního-předpisu-ze-sbírky-zákonů a skos:Concept;
   skos:prefLabel "Part of Legal Norm from the Collection of Laws of the Czech Republic"@en,
     "Část právního předpisu ze sbírky zákonů"@cs .
 
-v-sgov-pojem:datová-sada a skos:Concept;
-  skos:broader z-sgov-pojem:druh, z-sgov-pojem:pasivní-objekt, z-sgov-pojem:typ-objektu;
-  skos:definition "Dataset is a set of related data."@en, "Datová sada označuje množinu souvisejících dat."@cs;
+v-sgov-pojem:právo a skos:Concept;
+  skos:broader z-sgov-pojem:typ-kvalitativní-vlastnosti, z-sgov-pojem:typ-vlastnosti,
+    z-sgov-pojem:vlastnost;
+  skos:definition "Právo je právní možnost právního subjektu se nějak chovat."@cs, "RIght is a legal possibility of a legal subject to act in some way."@en;
   skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Dataset"@en, "Datová sada"@cs .
+  skos:prefLabel "Právo"@cs, "Right"@en .
+
+v-sgov-pojem:organizace a skos:Concept;
+  skos:broader z-sgov-pojem:agent, z-sgov-pojem:druh, z-sgov-pojem:typ-objektu;
+  skos:definition "Organizace je uskupení lidí, které je agentem."@cs, "Organization is any group of people, which is also an agent."@en;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Organizace"@cs, "Organization"@en .
 
 v-sgov-pojem:je-evidencí-pro a skos:Concept;
   skos:broader z-sgov-pojem:typ-vztahu, z-sgov-pojem:vztah;
@@ -100,46 +190,142 @@ v-sgov-pojem:má-zdrojový-předpis a skos:Concept;
   skos:inScheme v-sgov:glosář;
   skos:prefLabel "has source norm"@en, "má zdrojový předpis"@cs .
 
-v-sgov-pojem:organizace a skos:Concept;
-  skos:broader z-sgov-pojem:agent, z-sgov-pojem:druh, z-sgov-pojem:typ-objektu;
-  skos:definition "Organizace je uskupení lidí, které je agentem."@cs, "Organization is any group of people, which is also an agent."@en;
+v-sgov-pojem:má-část-znění a skos:Concept;
   skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Organizace"@cs, "Organization"@en .
+  skos:prefLabel "má část znění"@cs .
 
-v-sgov-pojem:právnická-osoba a skos:Concept;
-  skos:broader v-sgov-pojem:organizace, v-sgov-pojem:subjekt-práva, z-sgov-pojem:role,
-    z-sgov-pojem:typ-objektu;
-  skos:definition "Legal Person is an organization as a legal subject."@en, "Právnická osoba je organizací, která je subjektem práva."@cs;
+v-sgov-pojem:novela-právního-předpisu a skos:Concept;
   skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Legal Entity"@en, "Právnická osoba"@cs .
+  skos:prefLabel "Novela právního předpisu"@cs .
 
-v-sgov-pojem:právo a skos:Concept;
+v-sgov-pojem:konsolidované-znění-právního-předpisu a skos:Concept;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Konsolidované znění právního předpisu"@cs .
+
+v-sgov-pojem:má-znění a skos:Concept;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "má znění"@cs .
+
+v-sgov-pojem:vyhlášené-znění-právního-předpisu a skos:Concept;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Vyhlášené znění právního předpisu"@cs .
+
+v-sgov-pojem:znění-právního-předpisu a skos:Concept;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Znění právního předpisu"@cs .
+
+v-sgov-pojem:novelizuje a skos:Concept;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "novelizuje"@cs .
+
+v-sgov-pojem:název-právního-předpisu a skos:Concept;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Název právního předpisu"@cs;
+  skos:scopeNote ""@cs .
+
+v-sgov-pojem:datová-sada a skos:Concept;
+  skos:broader z-sgov-pojem:druh, z-sgov-pojem:pasivní-objekt, z-sgov-pojem:typ-objektu;
+  skos:definition "Dataset is a set of related data."@en, "Datová sada označuje množinu souvisejících dat."@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Dataset"@en, "Datová sada"@cs .
+
+v-sgov-pojem:dokument a skos:Concept;
+  skos:broader z-sgov-pojem:kategorie, z-sgov-pojem:pasivní-objekt, z-sgov-pojem:typ-objektu;
+  skos:definition "Document is a piece of written, printed, or electronic matter that provides information."@en,
+    "Dokument je psaný, tištěný nebo elektronický materiál poskytujícího informace."@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Document"@en, "Dokument"@cs .
+
+v-sgov-pojem:povinnost a skos:Concept;
   skos:broader z-sgov-pojem:typ-kvalitativní-vlastnosti, z-sgov-pojem:typ-vlastnosti,
     z-sgov-pojem:vlastnost;
-  skos:definition "Právo je právní možnost právního subjektu se nějak chovat."@cs, "RIght is a legal possibility of a legal subject to act in some way."@en;
+  skos:definition "Duty is a commitment to do, give, omit to do, or tolerate."@en, "Povinnost je závazek něco udělat, dát, nedělat, nebo strpět."@cs;
   skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Právo"@cs, "Right"@en .
+  skos:prefLabel "Duty"@en, "Povinnost"@cs .
 
-v-sgov-pojem:veřejnoprávní-korporace a skos:Concept;
-  skos:broader v-sgov-pojem:organizace, z-sgov-pojem:kategorie, z-sgov-pojem:typ-objektu;
-  skos:definition "A statutory corporation is a corporation created by the state."@en,
-    "Veřejnoprávní korporace je organizace, která je založena na základě zákona a které byla svěřena pravomoc plnit vymezené úkoly ve veřejné správě."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Statutory corporation"@en, "Veřejnoprávní korporace"@cs .
-
-v-sgov-pojem:objekt-práva a skos:Concept;
-  skos:broader z-sgov-pojem:mixin-rolí, z-sgov-pojem:objekt, z-sgov-pojem:typ-objektu;
-  skos:definition "Legal object is the reason for establishing the Legal Relationship."@en,
-    "Objekt práva je příčinou vstupu subjektu do právního vztahu."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Legal Object"@en, "Objekt práva"@cs .
-
-v-sgov-pojem:právní-vztah a skos:Concept;
+v-sgov-pojem:má-část-právního-předpisu a skos:Concept;
   skos:broader z-sgov-pojem:typ-vztahu, z-sgov-pojem:vztah;
-  skos:definition "Legal Relationship is a social relation of two or more legal subjects that have mutual rights and obligations"@en,
-    "Právní vztah je společenský vztah dvou nebo více subjektů práva, které mají vzájemná práva a povinnosti"@cs;
+  skos:definition "'has legal norm part 'denotes a relation between a legal norm from the Collection of laws of the Czech Republic and its part."@en,
+    "'má část právního předpisu' označuje vztah mezi právním předpisem ze sbírky zákonů a částí tohoto právního přepisu."@cs;
   skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Legal Relationship"@en, "Právní vztah"@cs .
+  skos:prefLabel "has legal norm part"@en, "má část právního předpisu"@cs .
+
+v-sgov-pojem:má-kontext a skos:Concept;
+  skos:broader z-sgov-pojem:typ-vztahu, z-sgov-pojem:vztah;
+  skos:definition "has context is a relation connecting a context document and the document that is needed to interpret it."@en,
+    "má kontext je vztah spojující kontextový dokument a dokument nutný k jeho interpretaci."@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "has context"@en, "má kontext"@cs .
+
+v-sgov-pojem:informační-systém a skos:Concept;
+  skos:broader z-sgov-pojem:kategorie, z-sgov-pojem:pasivní-objekt, z-sgov-pojem:typ-objektu;
+  skos:definition "Information System is an organized system for the collection, organization, storage and communication of information."@en,
+    "Informační systém je systém vzájemně propojených prostředků a procesů, které slouží k ukládání, zpracovávání a poskytování informací."@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Information System"@en, "Informační systém"@cs .
+
+v-sgov-pojem:způsobilost-k-právnímu-jednání a skos:Concept;
+  skos:broader z-sgov-pojem:typ-kvalitativní-vlastnosti, z-sgov-pojem:typ-vlastnosti,
+    z-sgov-pojem:vlastnost;
+  skos:definition "Legal Capacity is a capability to exercise rights and duties."@en,
+    "Způsobilost k právnímu jednání označuje schopnost vlastním jednáním nabývat práv a plnit povinnosti."@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Legal Capacity"@en, "Způsobilost k právnímu jednání"@cs .
+
+v-sgov-pojem:způsobilost-k-právům-a-povinnostem a skos:Concept;
+  skos:broader z-sgov-pojem:typ-kvalitativní-vlastnosti, z-sgov-pojem:typ-vlastnosti,
+    z-sgov-pojem:vlastnost;
+  skos:definition "Capacity to Rights and Duties is a possibility of a legal subject to have rights and duties."@en,
+    "Způsobilost k právům a povinnostem označuje vlastnost subjektu práva mít práva a povinnosti, pokud nastanou právem předvídané okolnosti. "@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Capacity to Rights and Duties"@en, "Způsobilost k právům a povinnostem"@cs .
+
+v-sgov-pojem:způsobilost-k-protiprávnímu-jednání a skos:Concept;
+  skos:broader z-sgov-pojem:typ-kvalitativní-vlastnosti, z-sgov-pojem:typ-vlastnosti,
+    z-sgov-pojem:vlastnost;
+  skos:definition "Capacity to unlawful acts denotes a capability to have legal responsibility for legal facts contrary the law."@en,
+    "Způsobilost k protiprávnímu jednání označuje schopnost nést právní odpovědnost za vlastní protiprávní jednání"@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Capacity to unlawful acts"@en, "Způsobilost k protiprávnímu jednání"@cs .
+
+v-sgov-pojem:typ-znalostní-struktury-dle-úrovně a skos:Concept;
+  skos:broader z-sgov-pojem:kategorie, z-sgov-pojem:typ, z-sgov-pojem:typ-objektu;
+  skos:definition "Knowledge Structure Type According to the Level is a type instances of which are categories of knowledge structures."@en,
+    "Typ znalostní struktury dle úrovně označuje typ, jehož instance jsou kategoriemi znalostních struktur."@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Knowledge Structure Type According to the Level"@en, "Typ znalostní struktury dle úrovně"@cs .
+
+v-sgov-pojem:výkon-svrchované-moci a skos:Concept;
+  skos:broader z-sgov-pojem:typ-vztahu, z-sgov-pojem:vztah;
+  skos:definition "Exercise of sovereign power denotes acts over its land and people."@en,
+    "Výkon svrchované moci označuje působení svrchované moci (státu) nad svým územím a obyvateli."@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Exercise of sovereign power"@en, "Výkon svrchované moci"@cs .
+
+v-sgov-pojem:typ-evidenčního-systému a skos:Concept;
+  skos:broader z-sgov-pojem:kategorie, z-sgov-pojem:typ-objektu, z-sgov-pojem:typ-proměnného-prvku;
+  skos:definition "Evidence System Type denotes a type instances of which categorize evidence systems."@en,
+    "Typ evidenčního systému označuje typ jehož instance kategorizují evidenční systémy."@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Evidence System Type"@en, "Typ evidenčního systému"@cs .
+
+v-sgov-pojem:jméno-právnické-osoby a skos:Concept;
+  skos:altLabel "Jméno"@cs, "Název"@cs;
+  skos:broader z-sgov-pojem:typ-kvalitativní-vlastnosti, z-sgov-pojem:typ-vlastnosti,
+    z-sgov-pojem:vlastnost;
+  skos:definition "Jméno právnické osoby"@cs, "Legal entity name"@en;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Jméno právnické osoby"@cs .
+
+v-sgov-pojem:prostorový-objekt a skos:Concept;
+  skos:broader z-sgov-pojem:objekt, z-sgov-pojem:typ-objektu;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Prostorový objekt"@cs .
+
+v-sgov-pojem:má-lokalizaci a skos:Concept;
+  skos:broader z-sgov-pojem:typ-vztahu, z-sgov-pojem:vztah;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "má lokalizaci"@cs .
 
 v-sgov-pojem:křestní-jméno a skos:Concept;
   skos:broader z-sgov-pojem:typ-kvalitativní-vlastnosti, z-sgov-pojem:typ-vlastnosti,
@@ -155,12 +341,39 @@ v-sgov-pojem:příjmení a skos:Concept;
   skos:inScheme v-sgov:glosář;
   skos:prefLabel "Příjmení"@cs, "Surname"@en .
 
-v-sgov-pojem:orgán-veřejné-moci a skos:Concept;
-  skos:broader v-sgov-pojem:organizace, z-sgov-pojem:poddruh, z-sgov-pojem:typ-objektu;
-  skos:definition "Orgán veřejné moci  je organizace, která reprezentuje veřejnou moc a je ze zákona oprávněna autoritativně rozhodovat o právech a povinnostech osob."@cs,
-    "Public Authority is an organization which has a legal mandate to govern, administrate some part of public life."@en;
+v-sgov-pojem:právní-vztah a skos:Concept;
+  skos:broader z-sgov-pojem:typ-vztahu, z-sgov-pojem:vztah;
+  skos:definition "Legal Relationship is a social relation of two or more legal subjects that have mutual rights and obligations"@en,
+    "Právní vztah je společenský vztah dvou nebo více subjektů práva, které mají vzájemná práva a povinnosti"@cs;
   skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Orgán veřejné moci"@cs, "Public Authority"@en .
+  skos:prefLabel "Legal Relationship"@en, "Právní vztah"@cs .
+
+v-sgov-pojem:objekt-práva a skos:Concept;
+  skos:broader z-sgov-pojem:mixin-rolí, z-sgov-pojem:objekt, z-sgov-pojem:typ-objektu;
+  skos:definition "Legal object is the reason for establishing the Legal Relationship."@en,
+    "Objekt práva je příčinou vstupu subjektu do právního vztahu."@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Legal Object"@en, "Objekt práva"@cs .
+
+v-sgov-pojem:evidenční-systém a skos:Concept;
+  skos:broader v-sgov-pojem:datová-sada, z-sgov-pojem:poddruh, z-sgov-pojem:typ-objektu;
+  skos:definition "Evidence System is a data set which records endurants."@en, "Evidenční systém je datová sada, která eviduje proměnné prvky."@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Evidence System"@en, "Evidenční systém"@cs .
+
+v-sgov-pojem:právnická-osoba a skos:Concept;
+  skos:broader v-sgov-pojem:organizace, v-sgov-pojem:subjekt-práva, z-sgov-pojem:role,
+    z-sgov-pojem:typ-objektu;
+  skos:definition "Legal Person is an organization as a legal subject."@en, "Právnická osoba je organizací, která je subjektem práva."@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Legal Entity"@en, "Právnická osoba"@cs .
+
+v-sgov-pojem:veřejnoprávní-korporace a skos:Concept;
+  skos:broader v-sgov-pojem:organizace, z-sgov-pojem:kategorie, z-sgov-pojem:typ-objektu;
+  skos:definition "A statutory corporation is a corporation created by the state."@en,
+    "Veřejnoprávní korporace je organizace, která je založena na základě zákona a které byla svěřena pravomoc plnit vymezené úkoly ve veřejné správě."@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Statutory corporation"@en, "Veřejnoprávní korporace"@cs .
 
 v-sgov-pojem:bezkontextový-dokument a skos:Concept;
   skos:broader v-sgov-pojem:dokument, z-sgov-pojem:kategorie, z-sgov-pojem:typ-objektu;
@@ -169,33 +382,77 @@ v-sgov-pojem:bezkontextový-dokument a skos:Concept;
   skos:inScheme v-sgov:glosář;
   skos:prefLabel "Bezkontextový dokument"@cs, "Context-free Document"@en .
 
-v-sgov-pojem:dokument a skos:Concept;
-  skos:broader z-sgov-pojem:kategorie, z-sgov-pojem:pasivní-objekt, z-sgov-pojem:typ-objektu;
-  skos:definition "Document is a piece of written, printed, or electronic matter that provides information."@en,
-    "Dokument je psaný, tištěný nebo elektronický materiál poskytujícího informace."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Document"@en, "Dokument"@cs .
-
-v-sgov-pojem:eviduje a skos:Concept;
-  skos:broader z-sgov-pojem:typ-vztahu, z-sgov-pojem:vztah;
-  skos:definition "'eviduje' označuje relator spojující evidenční systém s evidovaným endurantem."@cs,
-    "'records' denotes a relator connecting an evidence system with an endurant."@en;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "eviduje"@cs, "records"@en .
-
-v-sgov-pojem:informační-systém a skos:Concept;
-  skos:broader z-sgov-pojem:kategorie, z-sgov-pojem:pasivní-objekt, z-sgov-pojem:typ-objektu;
-  skos:definition "Information System is an organized system for the collection, organization, storage and communication of information."@en,
-    "Informační systém je systém vzájemně propojených prostředků a procesů, které slouží k ukládání, zpracovávání a poskytování informací."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Information System"@en, "Informační systém"@cs .
-
 v-sgov-pojem:kontextový-dokument a skos:Concept;
   skos:broader v-sgov-pojem:dokument, z-sgov-pojem:kategorie, z-sgov-pojem:typ-objektu;
   skos:definition "Context document is a document which requires another document to interpret it."@en,
     "Kontextový dokument je dokument, který je vyžaduje ke své interpretaci kontext"@cs;
   skos:inScheme v-sgov:glosář;
   skos:prefLabel "Context Document"@en, "Kontextový dokument"@cs .
+
+v-sgov-pojem:geografický-název a skos:Concept;
+  skos:broader v-sgov-pojem:lokalizace-popisem, z-sgov-pojem:typ-objektu;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Geografický název"@cs .
+
+v-sgov-pojem:lokalizace-popisem a skos:Concept;
+  skos:broader v-sgov-pojem:lokalizace-prostorového-objektu, z-sgov-pojem:typ-objektu;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Lokalizace popisem"@cs .
+
+v-sgov-pojem:geometrie a skos:Concept;
+  skos:broader v-sgov-pojem:lokalizace-prostorového-objektu, z-sgov-pojem:typ-objektu;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Geometrie"@cs .
+
+v-sgov-pojem:lokalizace-prostorového-objektu a skos:Concept;
+  skos:broader v-sgov-pojem:prostorový-objekt, z-sgov-pojem:typ-objektu;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Lokalizace prostorového objektu"@cs .
+
+v-sgov-pojem:lokalizace-vyjádřená-prostorovým-objektem a skos:Concept;
+  skos:broader v-sgov-pojem:lokalizace-prostorového-objektu, v-sgov-pojem:prostorový-objekt,
+    z-sgov-pojem:typ-objektu;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Lokalizace vyjádřená prostorovým objektem"@cs .
+
+v-sgov-pojem:má-definiční-lokalizaci a skos:Concept;
+  skos:broader v-sgov-pojem:má-lokalizaci, z-sgov-pojem:typ-vztahu;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "má definiční lokalizaci"@cs .
+
+v-sgov-pojem:má-geometrii a skos:Concept;
+  skos:broader v-sgov-pojem:má-lokalizaci, z-sgov-pojem:typ-vztahu;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "má geometrii"@cs .
+
+v-sgov-pojem:má-lokalizaci-názvem a skos:Concept;
+  skos:broader v-sgov-pojem:má-lokalizaci-popisem, z-sgov-pojem:typ-vztahu;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "má lokalizaci názvem"@cs .
+
+v-sgov-pojem:má-lokalizaci-popisem a skos:Concept;
+  skos:broader v-sgov-pojem:má-lokalizaci, z-sgov-pojem:typ-vztahu;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "má lokalizaci popisem"@cs .
+
+v-sgov-pojem:má-vztah-k-prostorovému-objektu a skos:Concept;
+  skos:broader v-sgov-pojem:má-lokalizaci, z-sgov-pojem:typ-vztahu;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "má vztah k prostorovému objektu"@cs .
+
+v-sgov-pojem:část a skos:Concept;
+  skos:broader v-sgov-pojem:část-znění-právního-předpisu, z-sgov-pojem:druh, z-sgov-pojem:typ-objektu;
+  skos:definition "Part as a Part of Legal Norm from the Collection of Laws of the Czech Republic"@en,
+    "Část jako část právního předpisu ze sbírky zákonů"@cs;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Part"@en, "Část"@cs .
+
+v-sgov-pojem:orgán-veřejné-moci a skos:Concept;
+  skos:broader v-sgov-pojem:organizace, z-sgov-pojem:poddruh, z-sgov-pojem:typ-objektu;
+  skos:definition "Orgán veřejné moci  je organizace, která reprezentuje veřejnou moc a je ze zákona oprávněna autoritativně rozhodovat o právech a povinnostech osob."@cs,
+    "Public Authority is an organization which has a legal mandate to govern, administrate some part of public life."@en;
+  skos:inScheme v-sgov:glosář;
+  skos:prefLabel "Orgán veřejné moci"@cs, "Public Authority"@en .
 
 v-sgov-pojem:legislativní-znalostní-struktura a skos:Concept;
   skos:broader v-sgov-pojem:znalostní-struktura, z-sgov-pojem:mixin-rolí, z-sgov-pojem:typ-objektu;
@@ -211,20 +468,6 @@ v-sgov-pojem:znalostní-struktura a skos:Concept;
   skos:inScheme v-sgov:glosář;
   skos:prefLabel "Knowledge Structure"@en, "Znalostní struktura"@cs .
 
-v-sgov-pojem:má-kontext a skos:Concept;
-  skos:broader z-sgov-pojem:typ-vztahu, z-sgov-pojem:vztah;
-  skos:definition "has context is a relation connecting a context document and the document that is needed to interpret it."@en,
-    "má kontext je vztah spojující kontextový dokument a dokument nutný k jeho interpretaci."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "has context"@en, "má kontext"@cs .
-
-v-sgov-pojem:má-část-právního-předpisu a skos:Concept;
-  skos:broader z-sgov-pojem:typ-vztahu, z-sgov-pojem:vztah;
-  skos:definition "'has legal norm part 'denotes a relation between a legal norm from the Collection of laws of the Czech Republic and its part."@en,
-    "'má část právního předpisu' označuje vztah mezi právním předpisem ze sbírky zákonů a částí tohoto právního přepisu."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "has legal norm part"@en, "má část právního předpisu"@cs .
-
 v-sgov-pojem:odstavec a skos:Concept;
   skos:broader v-sgov-pojem:část-znění-právního-předpisu, z-sgov-pojem:druh, z-sgov-pojem:typ-objektu;
   skos:definition "Odstavec jako část právního předpisu ze sbírky zákonů"@cs, "Section as a Part of Legal Norm from the Collection of Laws of the Czech Republic"@en;
@@ -236,13 +479,6 @@ v-sgov-pojem:paragraf a skos:Concept;
   skos:definition "Paragraf jako část právního předpisu ze sbírky zákonů"@cs, "Paragraph as a Part of Legal Norm from the Collection of Laws of the Czech Republic"@en;
   skos:inScheme v-sgov:glosář;
   skos:prefLabel "Paragraf"@cs, "Paragraph"@en .
-
-v-sgov-pojem:povinnost a skos:Concept;
-  skos:broader z-sgov-pojem:typ-kvalitativní-vlastnosti, z-sgov-pojem:typ-vlastnosti,
-    z-sgov-pojem:vlastnost;
-  skos:definition "Duty is a commitment to do, give, omit to do, or tolerate."@en, "Povinnost je závazek něco udělat, dát, nedělat, nebo strpět."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Duty"@en, "Povinnost"@cs .
 
 v-sgov-pojem:primární-objekt-práva a skos:Concept;
   skos:broader v-sgov-pojem:objekt-práva, z-sgov-pojem:mixin-rolí, z-sgov-pojem:typ-objektu;
@@ -323,238 +559,7 @@ v-sgov-pojem:stát a skos:Concept;
   skos:inScheme v-sgov:glosář;
   skos:prefLabel "State"@en, "Stát"@cs .
 
-v-sgov-pojem:typ-evidenčního-systému a skos:Concept;
-  skos:broader z-sgov-pojem:kategorie, z-sgov-pojem:typ-objektu, z-sgov-pojem:typ-proměnného-prvku;
-  skos:definition "Evidence System Type denotes a type instances of which categorize evidence systems."@en,
-    "Typ evidenčního systému označuje typ jehož instance kategorizují evidenční systémy."@cs;
+v-sgov-pojem:spravuje a skos:Concept;
+  skos:definition "Vztah mezi informačním systémem a datovou sadou. Informační systém spravuje datovou sadu. Všechna data uložená v úložišti (typicky databáze), ke které informační systém přistupuje, tvoří okamžitou verzi této datové sady."@cs;
   skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Evidence System Type"@en, "Typ evidenčního systému"@cs .
-
-v-sgov-pojem:typ-znalostní-struktury-dle-úrovně a skos:Concept;
-  skos:broader z-sgov-pojem:kategorie, z-sgov-pojem:typ, z-sgov-pojem:typ-objektu;
-  skos:definition "Knowledge Structure Type According to the Level is a type instances of which are categories of knowledge structures."@en,
-    "Typ znalostní struktury dle úrovně označuje typ, jehož instance jsou kategoriemi znalostních struktur."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Knowledge Structure Type According to the Level"@en, "Typ znalostní struktury dle úrovně"@cs .
-
-v-sgov-pojem:výkon-svrchované-moci a skos:Concept;
-  skos:broader z-sgov-pojem:typ-vztahu, z-sgov-pojem:vztah;
-  skos:definition "Exercise of sovereign power denotes acts over its land and people."@en,
-    "Výkon svrchované moci označuje působení svrchované moci (státu) nad svým územím a obyvateli."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Exercise of sovereign power"@en, "Výkon svrchované moci"@cs .
-
-v-sgov-pojem:způsobilost-k-protiprávnímu-jednání a skos:Concept;
-  skos:broader z-sgov-pojem:typ-kvalitativní-vlastnosti, z-sgov-pojem:typ-vlastnosti,
-    z-sgov-pojem:vlastnost;
-  skos:definition "Capacity to unlawful acts denotes a capability to have legal responsibility for legal facts contrary the law."@en,
-    "Způsobilost k protiprávnímu jednání označuje schopnost nést právní odpovědnost za vlastní protiprávní jednání"@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Capacity to unlawful acts"@en, "Způsobilost k protiprávnímu jednání"@cs .
-
-v-sgov-pojem:způsobilost-k-právnímu-jednání a skos:Concept;
-  skos:broader z-sgov-pojem:typ-kvalitativní-vlastnosti, z-sgov-pojem:typ-vlastnosti,
-    z-sgov-pojem:vlastnost;
-  skos:definition "Legal Capacity is a capability to exercise rights and duties."@en,
-    "Způsobilost k právnímu jednání označuje schopnost vlastním jednáním nabývat práv a plnit povinnosti."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Legal Capacity"@en, "Způsobilost k právnímu jednání"@cs .
-
-v-sgov-pojem:způsobilost-k-právům-a-povinnostem a skos:Concept;
-  skos:broader z-sgov-pojem:typ-kvalitativní-vlastnosti, z-sgov-pojem:typ-vlastnosti,
-    z-sgov-pojem:vlastnost;
-  skos:definition "Capacity to Rights and Duties is a possibility of a legal subject to have rights and duties."@en,
-    "Způsobilost k právům a povinnostem označuje vlastnost subjektu práva mít práva a povinnosti, pokud nastanou právem předvídané okolnosti. "@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Capacity to Rights and Duties"@en, "Způsobilost k právům a povinnostem"@cs .
-
-v-sgov-pojem:geografický-název a skos:Concept;
-  skos:broader v-sgov-pojem:lokalizace-popisem, z-sgov-pojem:typ-objektu;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Geografický název"@cs .
-
-v-sgov-pojem:lokalizace-popisem a skos:Concept;
-  skos:broader v-sgov-pojem:lokalizace-prostorového-objektu, z-sgov-pojem:typ-objektu;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Lokalizace popisem"@cs .
-
-v-sgov-pojem:geometrie a skos:Concept;
-  skos:broader v-sgov-pojem:lokalizace-prostorového-objektu, z-sgov-pojem:typ-objektu;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Geometrie"@cs .
-
-v-sgov-pojem:lokalizace-prostorového-objektu a skos:Concept;
-  skos:broader v-sgov-pojem:prostorový-objekt, z-sgov-pojem:typ-objektu;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Lokalizace prostorového objektu"@cs .
-
-v-sgov-pojem:lokalizace-vyjádřená-prostorovým-objektem a skos:Concept;
-  skos:broader v-sgov-pojem:lokalizace-prostorového-objektu, v-sgov-pojem:prostorový-objekt,
-    z-sgov-pojem:typ-objektu;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Lokalizace vyjádřená prostorovým objektem"@cs .
-
-v-sgov-pojem:prostorový-objekt a skos:Concept;
-  skos:broader z-sgov-pojem:objekt, z-sgov-pojem:typ-objektu;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Prostorový objekt"@cs .
-
-v-sgov-pojem:má-definiční-lokalizaci a skos:Concept;
-  skos:broader v-sgov-pojem:má-lokalizaci, z-sgov-pojem:typ-vztahu;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "má definiční lokalizaci"@cs .
-
-v-sgov-pojem:má-lokalizaci a skos:Concept;
-  skos:broader z-sgov-pojem:typ-vztahu, z-sgov-pojem:vztah;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "má lokalizaci"@cs .
-
-v-sgov-pojem:má-geometrii a skos:Concept;
-  skos:broader v-sgov-pojem:má-lokalizaci, z-sgov-pojem:typ-vztahu;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "má geometrii"@cs .
-
-v-sgov-pojem:má-lokalizaci-názvem a skos:Concept;
-  skos:broader v-sgov-pojem:má-lokalizaci-popisem, z-sgov-pojem:typ-vztahu;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "má lokalizaci názvem"@cs .
-
-v-sgov-pojem:má-lokalizaci-popisem a skos:Concept;
-  skos:broader v-sgov-pojem:má-lokalizaci, z-sgov-pojem:typ-vztahu;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "má lokalizaci popisem"@cs .
-
-v-sgov-pojem:má-platnost a skos:Concept;
-  skos:broader z-sgov-pojem:typ-vztahu, z-sgov-pojem:vztah;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "má platnost"@cs .
-
-v-sgov-pojem:má-vztah-k-prostorovému-objektu a skos:Concept;
-  skos:broader v-sgov-pojem:má-lokalizaci, z-sgov-pojem:typ-vztahu;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "má vztah k prostorovému objektu"@cs .
-
-v-sgov-pojem:popisuje a skos:Concept;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "describes"@en, "popisuje"@cs .
-
-v-sgov-pojem:má-znění a skos:Concept;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "má znění"@cs .
-
-v-sgov-pojem:má-část-znění a skos:Concept;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "má část znění"@cs .
-
-v-sgov-pojem:novelizuje a skos:Concept;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "novelizuje"@cs .
-
-v-sgov-pojem:název-právního-předpisu a skos:Concept;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Název právního předpisu"@cs;
-  skos:scopeNote ""@cs .
-
-v-sgov-pojem:novela-právního-předpisu a skos:Concept;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Novela právního předpisu"@cs .
-
-v-sgov-pojem:konsolidované-znění-právního-předpisu a skos:Concept;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Konsolidované znění právního předpisu"@cs .
-
-v-sgov-pojem:část-znění-právního-předpisu a skos:Concept;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Část znění právního předpisu"@cs .
-
-v-sgov-pojem:vyhlášené-znění-právního-předpisu a skos:Concept;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Vyhlášené znění právního předpisu"@cs .
-
-v-sgov-pojem:znění-právního-předpisu a skos:Concept;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Znění právního předpisu"@cs .
-
-v-sgov-pojem:část a skos:Concept;
-  skos:broader v-sgov-pojem:část-znění-právního-předpisu, z-sgov-pojem:druh, z-sgov-pojem:typ-objektu;
-  skos:definition "Part as a Part of Legal Norm from the Collection of Laws of the Czech Republic"@en,
-    "Část jako část právního předpisu ze sbírky zákonů"@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Part"@en, "Část"@cs .
-
-v-sgov-pojem:jméno-právnické-osoby a skos:Concept;
-  skos:altLabel "Jméno"@cs, "Název"@cs;
-  skos:broader z-sgov-pojem:typ-kvalitativní-vlastnosti, z-sgov-pojem:typ-vlastnosti,
-    z-sgov-pojem:vlastnost;
-  skos:definition "Jméno právnické osoby"@cs, "Legal entity name"@en;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Jméno právnické osoby"@cs .
-
-v-sgov-pojem:položka a skos:Concept;
-  skos:definition "Položka je proměnný prvek evidovaný v datové sadě. Položka má vlastní identitu."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Položka"@cs .
-
-v-sgov-pojem:kód-číselníku a skos:Concept;
-  skos:altLabel "kód"@cs;
-  skos:definition "Kód číselníku identifikuje číselník."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "kód číselníku"@cs .
-
-v-sgov-pojem:akronym-číselníku a skos:Concept;
-  skos:altLabel "akronym"@cs;
-  skos:definition "Zkratka číselníku používaná i jako jeho identifikátor."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "akronym číselníku"@cs .
-
-v-sgov-pojem:definice-číselníku a skos:Concept;
-  skos:altLabel "definice"@cs;
-  skos:definition "Delší text přesně definující číselník a položky, které eviduje."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "definice číselníku"@cs .
-
-v-sgov-pojem:má-administrativní-platnost-číselníku a skos:Concept;
-  skos:altLabel "má platnost"@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "má administrativní platnost číselníku"@cs .
-
-v-sgov-pojem:má-administrativní-platnost-položky a skos:Concept;
-  skos:altLabel "má platnost"@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "má administrativní platnost položky"@cs .
-
-v-sgov-pojem:pokrývá-oblast a skos:Concept;
-  skos:definition "Vymezuje významovou oblast (doménu), kterou pokrývá evidenční systém a v něm evidované položky."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "pokrývá oblast"@cs .
-
-v-sgov-pojem:položka-evidenčního-systému a skos:Concept;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Položka evidenčního systému"@cs .
-
-v-sgov-pojem:digitální-objekt a skos:Concept;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Digitální objekt"@cs .
-
-v-sgov-pojem:má-čas-vytvoření a skos:Concept;
-  skos:altLabel "vytvořen"@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "has creation time"@en, "má čas vytvoření"@cs .
-
-v-sgov-pojem:má-čas-poslední-aktualizace a skos:Concept;
-  skos:altLabel "aktualizován"@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "has last update time"@en, "má čas poslední aktualizace"@cs .
-
-v-sgov-pojem:eviduje-položku-evidenčního-systému a skos:Concept;
-  skos:altLabel "eviduje"@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "eviduje položku evidenčního systému"@cs, "records evidence system record"@en .
-
-v-sgov-pojem:popsaný-prvek a skos:Concept;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "Popsaný prvek"@cs, "described entity"@en .
-
-v-sgov-pojem:má-přílohu a skos:Concept;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "has attachment"@en, "má přílohu"@cs .
+  skos:prefLabel "spravuje"@cs .

--- a/content/v-sgov/v-sgov-glosář.ttl
+++ b/content/v-sgov/v-sgov-glosář.ttl
@@ -19,20 +19,18 @@ v-sgov:glosář a a-popis-dat-pojem:glosář, owl:NamedIndividual, owl:Ontology,
   vann:preferredNamespaceUri "https://slovník.gov.cz/veřejný-sektor/pojem/";
   owl:imports <https://slovník.gov.cz/základní/glosář/verze/1.0.1>;
   owl:versionIRI <https://slovník.gov.cz/veřejný-sektor/glosář/verze/1.0.0>;
-  skos:hasTopConcept v-sgov-pojem:akronym-číselníku, v-sgov-pojem:datová-sada, v-sgov-pojem:definice-číselníku,
-    v-sgov-pojem:digitální-objekt, v-sgov-pojem:dokument, v-sgov-pojem:eviduje, v-sgov-pojem:eviduje-položku-evidenčního-systému,
-    v-sgov-pojem:informační-systém, v-sgov-pojem:je-evidencí-pro, v-sgov-pojem:jméno-právnické-osoby,
-    v-sgov-pojem:konsolidované-znění-právního-předpisu, v-sgov-pojem:kód-číselníku, v-sgov-pojem:křestní-jméno,
-    v-sgov-pojem:má-administrativní-platnost-položky, v-sgov-pojem:má-administrativní-platnost-číselníku,
-    v-sgov-pojem:má-kontext, v-sgov-pojem:má-lokalizaci, v-sgov-pojem:má-platnost, v-sgov-pojem:má-přílohu,
-    v-sgov-pojem:má-zdrojový-předpis, v-sgov-pojem:má-znění, v-sgov-pojem:má-čas-poslední-aktualizace,
-    v-sgov-pojem:má-čas-vytvoření, v-sgov-pojem:má-část-právního-předpisu, v-sgov-pojem:má-část-znění,
-    v-sgov-pojem:novela-právního-předpisu, v-sgov-pojem:novelizuje, v-sgov-pojem:název-právního-předpisu,
-    v-sgov-pojem:objekt-práva, v-sgov-pojem:organizace, v-sgov-pojem:pokrývá-oblast, v-sgov-pojem:položka,
-    v-sgov-pojem:položka-evidenčního-systému, v-sgov-pojem:popisuje, v-sgov-pojem:popsaný-prvek,
-    v-sgov-pojem:povinnost, v-sgov-pojem:prostorový-objekt, v-sgov-pojem:právní-vztah,
-    v-sgov-pojem:právo, v-sgov-pojem:příjmení, v-sgov-pojem:spravuje, v-sgov-pojem:subjekt-práva,
-    v-sgov-pojem:typ-evidenčního-systému, v-sgov-pojem:typ-znalostní-struktury-dle-úrovně,
+  skos:hasTopConcept v-sgov-pojem:datová-sada, v-sgov-pojem:digitální-objekt, v-sgov-pojem:dokument,
+    v-sgov-pojem:eviduje, v-sgov-pojem:eviduje-položku-evidenčního-systému, v-sgov-pojem:informační-systém,
+    v-sgov-pojem:je-evidencí-pro, v-sgov-pojem:jméno-právnické-osoby, v-sgov-pojem:konsolidované-znění-právního-předpisu,
+    v-sgov-pojem:křestní-jméno, v-sgov-pojem:má-administrativní-platnost-položky, v-sgov-pojem:má-kontext,
+    v-sgov-pojem:má-lokalizaci, v-sgov-pojem:má-platnost, v-sgov-pojem:má-přílohu, v-sgov-pojem:má-zdrojový-předpis,
+    v-sgov-pojem:má-znění, v-sgov-pojem:má-čas-poslední-aktualizace, v-sgov-pojem:má-čas-vytvoření,
+    v-sgov-pojem:má-část-právního-předpisu, v-sgov-pojem:má-část-znění, v-sgov-pojem:novela-právního-předpisu,
+    v-sgov-pojem:novelizuje, v-sgov-pojem:název-právního-předpisu, v-sgov-pojem:objekt-práva,
+    v-sgov-pojem:organizace, v-sgov-pojem:pokrývá-oblast, v-sgov-pojem:položka, v-sgov-pojem:položka-evidenčního-systému,
+    v-sgov-pojem:popisuje, v-sgov-pojem:popsaný-prvek, v-sgov-pojem:povinnost, v-sgov-pojem:prostorový-objekt,
+    v-sgov-pojem:právní-vztah, v-sgov-pojem:právo, v-sgov-pojem:příjmení, v-sgov-pojem:spravuje,
+    v-sgov-pojem:subjekt-práva, v-sgov-pojem:typ-evidenčního-systému, v-sgov-pojem:typ-znalostní-struktury-dle-úrovně,
     v-sgov-pojem:vyhlášené-znění-právního-předpisu, v-sgov-pojem:výkon-svrchované-moci,
     v-sgov-pojem:znění-právního-předpisu, v-sgov-pojem:způsobilost-k-protiprávnímu-jednání,
     v-sgov-pojem:způsobilost-k-právnímu-jednání, v-sgov-pojem:způsobilost-k-právům-a-povinnostem,
@@ -58,37 +56,14 @@ v-sgov-pojem:subjekt-práva a skos:Concept;
   skos:inScheme v-sgov:glosář;
   skos:prefLabel "Legal Subject"@en, "Subjekt práva"@cs .
 
-v-sgov-pojem:akronym-číselníku a skos:Concept;
-  skos:altLabel "akronym"@cs;
-  skos:definition "Zkratka číselníku používaná i jako jeho identifikátor."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "akronym číselníku"@cs .
-
-v-sgov-pojem:definice-číselníku a skos:Concept;
-  skos:altLabel "definice"@cs;
-  skos:definition "Delší text přesně definující číselník a položky, které eviduje."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "definice číselníku"@cs .
-
 v-sgov-pojem:digitální-objekt a skos:Concept;
   skos:inScheme v-sgov:glosář;
   skos:prefLabel "Digitální objekt"@cs .
-
-v-sgov-pojem:kód-číselníku a skos:Concept;
-  skos:altLabel "kód"@cs;
-  skos:definition "Kód číselníku identifikuje číselník."@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "kód číselníku"@cs .
 
 v-sgov-pojem:má-administrativní-platnost-položky a skos:Concept;
   skos:altLabel "má platnost"@cs;
   skos:inScheme v-sgov:glosář;
   skos:prefLabel "má administrativní platnost položky"@cs .
-
-v-sgov-pojem:má-administrativní-platnost-číselníku a skos:Concept;
-  skos:altLabel "má platnost"@cs;
-  skos:inScheme v-sgov:glosář;
-  skos:prefLabel "má administrativní platnost číselníku"@cs .
 
 v-sgov-pojem:má-platnost a skos:Concept;
   skos:broader z-sgov-pojem:typ-vztahu, z-sgov-pojem:vztah;

--- a/content/v-sgov/v-sgov-model.ttl
+++ b/content/v-sgov/v-sgov-model.ttl
@@ -37,18 +37,12 @@ v-sgov-pojem:subjekt-práva a owl:Class, owl:NamedIndividual, z-sgov-pojem:mixin
     z-sgov-pojem:typ-objektu;
   rdfs:subClassOf z-sgov-pojem:agent .
 
-v-sgov-pojem:akronym-číselníku a z-sgov-pojem:typ-vlastnosti .
-
 skos:altLabel a owl:AnnotationProperty .
-
-v-sgov-pojem:definice-číselníku a z-sgov-pojem:typ-vlastnosti .
 
 v-sgov-pojem:digitální-objekt a z-sgov-pojem:kategorie, z-sgov-pojem:typ-objektu;
   rdfs:subClassOf z-sgov-pojem:pasivní-objekt .
 
 z-sgov-pojem:pasivní-objekt a owl:Class .
-
-v-sgov-pojem:kód-číselníku a z-sgov-pojem:typ-vlastnosti .
 
 v-sgov-pojem:má-administrativní-platnost-položky a z-sgov-pojem:typ-vztahu;
   rdfs:subClassOf [ a owl:Restriction;
@@ -67,9 +61,6 @@ v-sgov-pojem:má-administrativní-platnost-položky a z-sgov-pojem:typ-vztahu;
       owl:allValuesFrom z-sgov-pojem:časový-prvek;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
     ] .
-
-v-sgov-pojem:má-administrativní-platnost-číselníku a z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf v-sgov-pojem:má-platnost .
 
 v-sgov-pojem:má-platnost a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
   rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;

--- a/content/v-sgov/v-sgov-model.ttl
+++ b/content/v-sgov/v-sgov-model.ttl
@@ -21,50 +21,334 @@ v-sgov:model a a-popis-dat-pojem:model, owl:Ontology;
   owl:imports <https://slovník.gov.cz/základní/model/plný/verze/1.0.1>;
   owl:versionIRI <https://slovník.gov.cz/veřejný-sektor/model/verze/1.0.0> .
 
-skos:scopeNote a owl:AnnotationProperty .
-
 skos:hasTopConcept a owl:AnnotationProperty .
 
 z-sgov-pojem:objekt a owl:Class .
 
-skos:altLabel a owl:AnnotationProperty .
-
-z-sgov-pojem:typ a owl:Class .
+skos:scopeNote a owl:AnnotationProperty .
 
 v-sgov-pojem:fyzická-osoba a owl:Class, owl:NamedIndividual, z-sgov-pojem:role, z-sgov-pojem:typ-objektu;
   rdfs:subClassOf v-sgov-pojem:subjekt-práva, v-sgov-pojem:člověk .
+
+v-sgov-pojem:člověk a owl:Class, owl:NamedIndividual, z-sgov-pojem:druh, z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf z-sgov-pojem:agent .
 
 v-sgov-pojem:subjekt-práva a owl:Class, owl:NamedIndividual, z-sgov-pojem:mixin-rolí,
     z-sgov-pojem:typ-objektu;
   rdfs:subClassOf z-sgov-pojem:agent .
 
-v-sgov-pojem:člověk a owl:Class, owl:NamedIndividual, z-sgov-pojem:druh, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf z-sgov-pojem:agent .
+v-sgov-pojem:akronym-číselníku a z-sgov-pojem:typ-vlastnosti .
+
+skos:altLabel a owl:AnnotationProperty .
+
+v-sgov-pojem:definice-číselníku a z-sgov-pojem:typ-vlastnosti .
+
+v-sgov-pojem:digitální-objekt a z-sgov-pojem:kategorie, z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf z-sgov-pojem:pasivní-objekt .
 
 z-sgov-pojem:pasivní-objekt a owl:Class .
 
-z-sgov-pojem:typ-proměnného-prvku a owl:Class .
+v-sgov-pojem:kód-číselníku a z-sgov-pojem:typ-vlastnosti .
 
-v-sgov-pojem:evidenční-systém a owl:Class, owl:NamedIndividual, z-sgov-pojem:mixin,
-    z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf v-sgov-pojem:datová-sada .
+v-sgov-pojem:má-administrativní-platnost-položky a z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf [ a owl:Restriction;
+      owl:allValuesFrom z-sgov-pojem:časový-prvek;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom v-sgov-pojem:položka
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom z-sgov-pojem:časový-prvek
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:položka;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:allValuesFrom z-sgov-pojem:časový-prvek;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ] .
+
+v-sgov-pojem:má-administrativní-platnost-číselníku a z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf v-sgov-pojem:má-platnost .
+
+v-sgov-pojem:má-platnost a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass z-sgov-pojem:časový-prvek;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:datová-sada;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass z-sgov-pojem:časový-prvek;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass z-sgov-pojem:časový-prvek;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass v-sgov-pojem:datová-sada;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom z-sgov-pojem:časový-prvek
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:datová-sada;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:allValuesFrom z-sgov-pojem:časový-prvek;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom v-sgov-pojem:datová-sada
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass v-sgov-pojem:datová-sada;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ] .
+
+v-sgov-pojem:pokrývá-oblast a z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom v-sgov-pojem:datová-sada
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass v-sgov-pojem:datová-sada;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:datová-sada;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass v-sgov-pojem:datová-sada;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom z-sgov-pojem:typ-objektu
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass z-sgov-pojem:typ-objektu;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:allValuesFrom z-sgov-pojem:typ-objektu;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass z-sgov-pojem:typ-objektu;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ] .
+
+v-sgov-pojem:položka-evidenčního-systému a z-sgov-pojem:mixin-rolí, z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf v-sgov-pojem:položka .
+
+v-sgov-pojem:položka a z-sgov-pojem:kategorie, z-sgov-pojem:typ-objektu;
+  dcterms:source "";
+  rdfs:subClassOf z-sgov-pojem:pasivní-objekt, [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:má-čas-vytvoření;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom v-sgov-pojem:má-čas-vytvoření
+    ] .
+
+v-sgov-pojem:eviduje-položku-evidenčního-systému a z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf v-sgov-pojem:eviduje, [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:evidenční-systém;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass v-sgov-pojem:položka-evidenčního-systému;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass v-sgov-pojem:evidenční-systém;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom v-sgov-pojem:evidenční-systém
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom v-sgov-pojem:položka-evidenčního-systému
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:položka-evidenčního-systému;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass v-sgov-pojem:položka-evidenčního-systému;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass v-sgov-pojem:evidenční-systém;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ] .
+
+v-sgov-pojem:eviduje a owl:Class, owl:NamedIndividual, z-sgov-pojem:druh, z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom v-sgov-pojem:položka
+    ], [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass v-sgov-pojem:datová-sada;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass v-sgov-pojem:položka;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass v-sgov-pojem:datová-sada;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom v-sgov-pojem:datová-sada
+    ], [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass v-sgov-pojem:položka;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:položka;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:datová-sada;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ] .
+
+v-sgov-pojem:má-přílohu a z-sgov-pojem:mixin, z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom v-sgov-pojem:položka
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom v-sgov-pojem:digitální-objekt
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:položka;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:digitální-objekt;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ] .
+
+v-sgov-pojem:má-čas-poslední-aktualizace a z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf [ a owl:Restriction;
+      owl:allValuesFrom z-sgov-pojem:proměnný-prvek;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass z-sgov-pojem:časový-okamžik;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass z-sgov-pojem:proměnný-prvek;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass z-sgov-pojem:proměnný-prvek;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom z-sgov-pojem:proměnný-prvek
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom z-sgov-pojem:časový-okamžik
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass z-sgov-pojem:časový-okamžik;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:allValuesFrom z-sgov-pojem:časový-okamžik;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ] .
+
+v-sgov-pojem:má-čas-vytvoření a z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf [ a owl:Restriction;
+      owl:allValuesFrom z-sgov-pojem:proměnný-prvek;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom z-sgov-pojem:proměnný-prvek
+    ], [ a owl:Restriction;
+      owl:allValuesFrom z-sgov-pojem:časový-okamžik;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom z-sgov-pojem:časový-okamžik
+    ] .
+
+v-sgov-pojem:popisuje a z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass v-sgov-pojem:popsaný-prvek;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:popsaný-prvek;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass v-sgov-pojem:položka;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom v-sgov-pojem:popsaný-prvek
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom v-sgov-pojem:položka
+    ], [ a owl:Restriction;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass v-sgov-pojem:položka;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:položka;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass v-sgov-pojem:popsaný-prvek;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ] .
+
+v-sgov-pojem:popsaný-prvek rdfs:subClassOf z-sgov-pojem:prvek .
 
 v-sgov-pojem:hlava a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-objektu;
   rdfs:subClassOf v-sgov-pojem:část-znění-právního-předpisu .
+
+v-sgov-pojem:část-znění-právního-předpisu a owl:NamedIndividual, z-sgov-pojem:druh,
+    z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf v-sgov-pojem:kontextový-dokument .
 
 v-sgov-pojem:část-právního-předpisu-ze-sbírky-zákonů a owl:Class, owl:NamedIndividual,
     z-sgov-pojem:kategorie, z-sgov-pojem:typ-objektu;
   rdfs:subClassOf v-sgov-pojem:kontextový-dokument .
 
-v-sgov-pojem:datová-sada a owl:Class, owl:NamedIndividual, z-sgov-pojem:mixin, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf v-sgov-pojem:popsaný-prvek, z-sgov-pojem:pasivní-objekt .
+v-sgov-pojem:právo a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-kvalitativní-vlastnosti,
+    z-sgov-pojem:typ-vlastnosti;
+  rdfs:subClassOf z-sgov-pojem:vlastnost, [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:subjekt-práva;
+      owl:onProperty z-sgov-pojem:je-vlastností
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:je-vlastností;
+      owl:someValuesFrom v-sgov-pojem:subjekt-práva
+    ] .
+
+v-sgov-pojem:organizace a owl:Class, owl:NamedIndividual, z-sgov-pojem:druh, z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf z-sgov-pojem:agent .
 
 v-sgov-pojem:je-evidencí-pro a owl:Class, owl:NamedIndividual, z-sgov-pojem:druh,
     z-sgov-pojem:typ-vztahu;
   rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:allValuesFrom z-sgov-pojem:typ-proměnného-prvku;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
       owl:onClass z-sgov-pojem:typ-proměnného-prvku;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:onClass v-sgov-pojem:typ-evidenčního-systému;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:typ-evidenčního-systému;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
     ], [ a owl:Restriction;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
       owl:someValuesFrom z-sgov-pojem:typ-proměnného-prvku
@@ -73,17 +357,7 @@ v-sgov-pojem:je-evidencí-pro a owl:Class, owl:NamedIndividual, z-sgov-pojem:dru
       owl:onClass v-sgov-pojem:typ-evidenčního-systému;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
     ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:typ-evidenčního-systému;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:allValuesFrom z-sgov-pojem:typ-proměnného-prvku;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass v-sgov-pojem:typ-evidenčního-systému;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
+      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
       owl:onClass z-sgov-pojem:typ-proměnného-prvku;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
     ], [ a owl:Restriction;
@@ -96,65 +370,221 @@ v-sgov-pojem:má-zdrojový-předpis a owl:Class, owl:NamedIndividual, z-sgov-poj
       owl:allValuesFrom v-sgov-pojem:legislativní-znalostní-struktura;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
     ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:právní-předpis;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
       owl:someValuesFrom v-sgov-pojem:legislativní-znalostní-struktura
     ], [ a owl:Restriction;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
       owl:someValuesFrom v-sgov-pojem:právní-předpis
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:právní-předpis;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
     ] .
 
-v-sgov-pojem:organizace a owl:Class, owl:NamedIndividual, z-sgov-pojem:druh, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf z-sgov-pojem:agent .
+v-sgov-pojem:má-část-znění a owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:část-znění-právního-předpisu;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom v-sgov-pojem:znění-právního-předpisu
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom v-sgov-pojem:část-znění-právního-předpisu
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:znění-právního-předpisu;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ] .
 
-z-sgov-pojem:agent a owl:Class .
-
-v-sgov-pojem:právnická-osoba a owl:Class, owl:NamedIndividual, z-sgov-pojem:role,
+v-sgov-pojem:novela-právního-předpisu a owl:NamedIndividual, z-sgov-pojem:poddruh,
     z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf v-sgov-pojem:organizace, v-sgov-pojem:subjekt-práva .
+  rdfs:subClassOf v-sgov-pojem:znění-právního-předpisu .
 
-v-sgov-pojem:právo a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-kvalitativní-vlastnosti,
-    z-sgov-pojem:typ-vlastnosti;
+v-sgov-pojem:konsolidované-znění-právního-předpisu a owl:NamedIndividual, z-sgov-pojem:poddruh,
+    z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf v-sgov-pojem:znění-právního-předpisu .
+
+v-sgov-pojem:má-znění a owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom v-sgov-pojem:právní-předpis
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom v-sgov-pojem:znění-právního-předpisu
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:znění-právního-předpisu;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:právní-předpis;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ] .
+
+v-sgov-pojem:vyhlášené-znění-právního-předpisu a owl:NamedIndividual, z-sgov-pojem:poddruh,
+    z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf v-sgov-pojem:znění-právního-předpisu .
+
+v-sgov-pojem:znění-právního-předpisu a owl:NamedIndividual, z-sgov-pojem:druh, z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf v-sgov-pojem:bezkontextový-dokument .
+
+v-sgov-pojem:novelizuje a owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:novela-právního-předpisu;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:znění-právního-předpisu;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom v-sgov-pojem:novela-právního-předpisu
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom v-sgov-pojem:znění-právního-předpisu
+    ] .
+
+v-sgov-pojem:název-právního-předpisu a owl:NamedIndividual, z-sgov-pojem:typ-vlastnosti;
   rdfs:subClassOf z-sgov-pojem:vlastnost, [ a owl:Restriction;
       owl:onProperty z-sgov-pojem:je-vlastností;
-      owl:someValuesFrom v-sgov-pojem:subjekt-práva
+      owl:someValuesFrom v-sgov-pojem:právní-předpis
     ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:subjekt-práva;
+      owl:allValuesFrom v-sgov-pojem:právní-předpis;
       owl:onProperty z-sgov-pojem:je-vlastností
     ] .
 
-v-sgov-pojem:veřejnoprávní-korporace a owl:Class, owl:NamedIndividual, z-sgov-pojem:poddruh,
-    z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf v-sgov-pojem:organizace .
+v-sgov-pojem:datová-sada a owl:Class, owl:NamedIndividual, z-sgov-pojem:mixin, z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf v-sgov-pojem:popsaný-prvek, z-sgov-pojem:pasivní-objekt .
 
-z-sgov-pojem:je-vlastností a owl:ObjectProperty;
-  owl:inverseOf z-sgov-pojem:má-vlastnost .
+v-sgov-pojem:dokument a owl:Class, owl:NamedIndividual, z-sgov-pojem:kategorie, z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf z-sgov-pojem:pasivní-objekt .
 
-z-sgov-pojem:má-vlastnost a owl:ObjectProperty .
+v-sgov-pojem:povinnost a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-kvalitativní-vlastnosti,
+    z-sgov-pojem:typ-vlastnosti;
+  rdfs:subClassOf z-sgov-pojem:vlastnost, [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:subjekt-práva;
+      owl:onProperty z-sgov-pojem:je-vlastností
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:je-vlastností;
+      owl:someValuesFrom v-sgov-pojem:subjekt-práva
+    ] .
 
-v-sgov-pojem:objekt-práva a owl:Class, owl:NamedIndividual, z-sgov-pojem:mixin-rolí,
-    z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf z-sgov-pojem:objekt .
-
-v-sgov-pojem:právní-vztah a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
+v-sgov-pojem:má-část-právního-předpisu a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
   rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:objekt-práva;
+      owl:allValuesFrom v-sgov-pojem:část-právního-předpisu-ze-sbírky-zákonů;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
     ], [ a owl:Restriction;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom v-sgov-pojem:objekt-práva
+      owl:someValuesFrom v-sgov-pojem:část-právního-předpisu-ze-sbírky-zákonů
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:právní-předpis-ze-sbírky-zákonů;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom v-sgov-pojem:právní-předpis-ze-sbírky-zákonů
+    ] .
+
+v-sgov-pojem:má-kontext a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom v-sgov-pojem:kontextový-dokument
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:dokument;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom v-sgov-pojem:dokument
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:kontextový-dokument;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ] .
+
+v-sgov-pojem:informační-systém a owl:Class, owl:NamedIndividual, z-sgov-pojem:kategorie,
+    z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf z-sgov-pojem:pasivní-objekt .
+
+v-sgov-pojem:způsobilost-k-právnímu-jednání a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-kvalitativní-vlastnosti,
+    z-sgov-pojem:typ-vlastnosti;
+  rdfs:subClassOf z-sgov-pojem:vlastnost, [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:subjekt-práva;
+      owl:onProperty z-sgov-pojem:je-vlastností
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:je-vlastností;
+      owl:someValuesFrom v-sgov-pojem:subjekt-práva
+    ] .
+
+v-sgov-pojem:způsobilost-k-právům-a-povinnostem a owl:Class, owl:NamedIndividual,
+    z-sgov-pojem:typ-kvalitativní-vlastnosti, z-sgov-pojem:typ-vlastnosti;
+  rdfs:subClassOf z-sgov-pojem:vlastnost, [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:subjekt-práva;
+      owl:onProperty z-sgov-pojem:je-vlastností
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:je-vlastností;
+      owl:someValuesFrom v-sgov-pojem:subjekt-práva
+    ] .
+
+v-sgov-pojem:způsobilost-k-protiprávnímu-jednání a owl:Class, owl:NamedIndividual,
+    z-sgov-pojem:typ-kvalitativní-vlastnosti, z-sgov-pojem:typ-vlastnosti;
+  rdfs:subClassOf z-sgov-pojem:vlastnost, [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:subjekt-práva;
+      owl:onProperty z-sgov-pojem:je-vlastností
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:je-vlastností;
+      owl:someValuesFrom v-sgov-pojem:subjekt-práva
+    ] .
+
+v-sgov-pojem:typ-znalostní-struktury-dle-úrovně a owl:Class, owl:NamedIndividual,
+    z-sgov-pojem:kategorie, z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf z-sgov-pojem:typ .
+
+v-sgov-pojem:výkon-svrchované-moci a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
+      owl:allValuesFrom [ a owl:Class;
+          owl:unionOf (v-sgov-pojem:stát v-sgov-pojem:subjekt-práva)
+        ];
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom [ a owl:Class;
+          owl:unionOf (v-sgov-pojem:stát v-sgov-pojem:subjekt-práva)
+        ]
+    ] .
+
+v-sgov-pojem:typ-evidenčního-systému a owl:Class, owl:NamedIndividual, z-sgov-pojem:kategorie,
+    z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf z-sgov-pojem:typ-objektu .
+
+v-sgov-pojem:jméno-právnické-osoby a owl:NamedIndividual, z-sgov-pojem:typ-vlastnosti;
+  rdfs:subClassOf z-sgov-pojem:vlastnost, [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:právnická-osoba;
+      owl:onProperty z-sgov-pojem:je-vlastností
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:je-vlastností;
+      owl:someValuesFrom v-sgov-pojem:právnická-osoba
+    ] .
+
+v-sgov-pojem:prostorový-objekt a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf z-sgov-pojem:objekt .
+
+v-sgov-pojem:má-lokalizaci a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:lokalizace-prostorového-objektu;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom v-sgov-pojem:lokalizace-prostorového-objektu
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:prostorový-objekt;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
+      owl:someValuesFrom v-sgov-pojem:prostorový-objekt
     ] .
 
 v-sgov-pojem:křestní-jméno a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-kvalitativní-vlastnosti,
     z-sgov-pojem:typ-vlastnosti;
   rdfs:subClassOf z-sgov-pojem:vlastnost, [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:fyzická-osoba;
-      owl:onProperty z-sgov-pojem:je-vlastností
-    ], [ a owl:Restriction;
       owl:onProperty z-sgov-pojem:je-vlastností;
       owl:someValuesFrom v-sgov-pojem:fyzická-osoba
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:fyzická-osoba;
+      owl:onProperty z-sgov-pojem:je-vlastností
     ] .
 
 v-sgov-pojem:příjmení a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-kvalitativní-vlastnosti,
@@ -167,55 +597,107 @@ v-sgov-pojem:příjmení a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-kval
       owl:someValuesFrom v-sgov-pojem:fyzická-osoba
     ] .
 
-v-sgov-pojem:orgán-veřejné-moci a owl:Class, owl:NamedIndividual, z-sgov-pojem:poddruh,
+v-sgov-pojem:právní-vztah a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom v-sgov-pojem:objekt-práva
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:objekt-práva;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ] .
+
+v-sgov-pojem:objekt-práva a owl:Class, owl:NamedIndividual, z-sgov-pojem:mixin-rolí,
+    z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf z-sgov-pojem:objekt .
+
+v-sgov-pojem:evidenční-systém a owl:Class, owl:NamedIndividual, z-sgov-pojem:mixin,
+    z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf v-sgov-pojem:datová-sada .
+
+z-sgov-pojem:agent a owl:Class .
+
+v-sgov-pojem:právnická-osoba a owl:Class, owl:NamedIndividual, z-sgov-pojem:role,
+    z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf v-sgov-pojem:organizace, v-sgov-pojem:subjekt-práva .
+
+v-sgov-pojem:veřejnoprávní-korporace a owl:Class, owl:NamedIndividual, z-sgov-pojem:poddruh,
     z-sgov-pojem:typ-objektu;
   rdfs:subClassOf v-sgov-pojem:organizace .
+
+z-sgov-pojem:je-vlastností a owl:ObjectProperty;
+  owl:inverseOf z-sgov-pojem:má-vlastnost .
+
+z-sgov-pojem:má-vlastnost a owl:ObjectProperty .
 
 v-sgov-pojem:bezkontextový-dokument a owl:Class, owl:NamedIndividual, z-sgov-pojem:kategorie,
     z-sgov-pojem:typ-objektu;
   rdfs:subClassOf v-sgov-pojem:dokument .
 
-v-sgov-pojem:dokument a owl:Class, owl:NamedIndividual, z-sgov-pojem:kategorie, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf z-sgov-pojem:pasivní-objekt .
-
-v-sgov-pojem:eviduje a owl:Class, owl:NamedIndividual, z-sgov-pojem:druh, z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:datová-sada;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
-      owl:someValuesFrom v-sgov-pojem:datová-sada
-    ], [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass v-sgov-pojem:datová-sada;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:položka;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass v-sgov-pojem:datová-sada;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass v-sgov-pojem:položka;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass v-sgov-pojem:položka;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom v-sgov-pojem:položka
-    ] .
-
-v-sgov-pojem:informační-systém a owl:Class, owl:NamedIndividual, z-sgov-pojem:kategorie,
-    z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf z-sgov-pojem:pasivní-objekt .
-
 v-sgov-pojem:kontextový-dokument a owl:Class, owl:NamedIndividual, z-sgov-pojem:kategorie,
     z-sgov-pojem:typ-objektu;
   rdfs:subClassOf v-sgov-pojem:dokument .
+
+v-sgov-pojem:geografický-název a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf v-sgov-pojem:lokalizace-popisem .
+
+v-sgov-pojem:lokalizace-popisem a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf v-sgov-pojem:lokalizace-prostorového-objektu .
+
+v-sgov-pojem:geometrie a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf v-sgov-pojem:lokalizace-prostorového-objektu .
+
+v-sgov-pojem:lokalizace-prostorového-objektu a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf v-sgov-pojem:prostorový-objekt .
+
+v-sgov-pojem:lokalizace-vyjádřená-prostorovým-objektem a owl:Class, owl:NamedIndividual,
+    z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf v-sgov-pojem:lokalizace-prostorového-objektu, v-sgov-pojem:prostorový-objekt .
+
+v-sgov-pojem:má-definiční-lokalizaci a owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf v-sgov-pojem:má-lokalizaci .
+
+v-sgov-pojem:má-geometrii a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf v-sgov-pojem:má-lokalizaci, [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom v-sgov-pojem:geometrie
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:geometrie;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ] .
+
+v-sgov-pojem:má-lokalizaci-názvem a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf v-sgov-pojem:má-lokalizaci-popisem, [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:geografický-název;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ], [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom v-sgov-pojem:geografický-název
+    ] .
+
+v-sgov-pojem:má-lokalizaci-popisem a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf v-sgov-pojem:má-lokalizaci, [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom v-sgov-pojem:lokalizace-popisem
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:lokalizace-popisem;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ] .
+
+v-sgov-pojem:má-vztah-k-prostorovému-objektu a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf v-sgov-pojem:má-lokalizaci, [ a owl:Restriction;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
+      owl:someValuesFrom v-sgov-pojem:lokalizace-vyjádřená-prostorovým-objektem
+    ], [ a owl:Restriction;
+      owl:allValuesFrom v-sgov-pojem:lokalizace-vyjádřená-prostorovým-objektem;
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+    ] .
+
+v-sgov-pojem:část a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf v-sgov-pojem:část-znění-právního-předpisu .
+
+v-sgov-pojem:orgán-veřejné-moci a owl:Class, owl:NamedIndividual, z-sgov-pojem:poddruh,
+    z-sgov-pojem:typ-objektu;
+  rdfs:subClassOf v-sgov-pojem:organizace .
 
 v-sgov-pojem:legislativní-znalostní-struktura a owl:Class, owl:NamedIndividual, z-sgov-pojem:mixin-rolí,
     z-sgov-pojem:typ-objektu;
@@ -225,51 +707,11 @@ v-sgov-pojem:znalostní-struktura a owl:Class, owl:NamedIndividual, z-sgov-pojem
     z-sgov-pojem:typ-objektu;
   rdfs:subClassOf v-sgov-pojem:datová-sada .
 
-v-sgov-pojem:má-kontext a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom v-sgov-pojem:kontextový-dokument
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:dokument;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:kontextový-dokument;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
-      owl:someValuesFrom v-sgov-pojem:dokument
-    ] .
-
-v-sgov-pojem:má-část-právního-předpisu a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
-      owl:someValuesFrom v-sgov-pojem:právní-předpis-ze-sbírky-zákonů
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:část-právního-předpisu-ze-sbírky-zákonů;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:právní-předpis-ze-sbírky-zákonů;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom v-sgov-pojem:část-právního-předpisu-ze-sbírky-zákonů
-    ] .
-
 v-sgov-pojem:odstavec a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-objektu;
   rdfs:subClassOf v-sgov-pojem:část-znění-právního-předpisu .
 
 v-sgov-pojem:paragraf a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-objektu;
   rdfs:subClassOf v-sgov-pojem:část-znění-právního-předpisu .
-
-v-sgov-pojem:povinnost a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-kvalitativní-vlastnosti,
-    z-sgov-pojem:typ-vlastnosti;
-  rdfs:subClassOf z-sgov-pojem:vlastnost, [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:je-vlastností;
-      owl:someValuesFrom v-sgov-pojem:subjekt-práva
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:subjekt-práva;
-      owl:onProperty z-sgov-pojem:je-vlastností
-    ] .
 
 v-sgov-pojem:primární-objekt-práva a owl:Class, owl:NamedIndividual, z-sgov-pojem:mixin-rolí,
     z-sgov-pojem:typ-objektu;
@@ -312,56 +754,9 @@ v-sgov-pojem:sekundární-objekt-práva a owl:Class, owl:NamedIndividual, z-sgov
 v-sgov-pojem:stát a owl:Class, owl:NamedIndividual, z-sgov-pojem:poddruh, z-sgov-pojem:typ-objektu;
   rdfs:subClassOf v-sgov-pojem:organizace .
 
-v-sgov-pojem:typ-evidenčního-systému a owl:Class, owl:NamedIndividual, z-sgov-pojem:kategorie,
-    z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf z-sgov-pojem:typ-objektu .
+z-sgov-pojem:typ-proměnného-prvku a owl:Class .
 
-v-sgov-pojem:typ-znalostní-struktury-dle-úrovně a owl:Class, owl:NamedIndividual,
-    z-sgov-pojem:kategorie, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf z-sgov-pojem:typ .
-
-v-sgov-pojem:výkon-svrchované-moci a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
-      owl:someValuesFrom [ a owl:Class;
-          owl:unionOf (v-sgov-pojem:stát v-sgov-pojem:subjekt-práva)
-        ]
-    ], [ a owl:Restriction;
-      owl:allValuesFrom [ a owl:Class;
-          owl:unionOf (v-sgov-pojem:stát v-sgov-pojem:subjekt-práva)
-        ];
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ] .
-
-v-sgov-pojem:způsobilost-k-protiprávnímu-jednání a owl:Class, owl:NamedIndividual,
-    z-sgov-pojem:typ-kvalitativní-vlastnosti, z-sgov-pojem:typ-vlastnosti;
-  rdfs:subClassOf z-sgov-pojem:vlastnost, [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:je-vlastností;
-      owl:someValuesFrom v-sgov-pojem:subjekt-práva
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:subjekt-práva;
-      owl:onProperty z-sgov-pojem:je-vlastností
-    ] .
-
-v-sgov-pojem:způsobilost-k-právnímu-jednání a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-kvalitativní-vlastnosti,
-    z-sgov-pojem:typ-vlastnosti;
-  rdfs:subClassOf z-sgov-pojem:vlastnost, [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:subjekt-práva;
-      owl:onProperty z-sgov-pojem:je-vlastností
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:je-vlastností;
-      owl:someValuesFrom v-sgov-pojem:subjekt-práva
-    ] .
-
-v-sgov-pojem:způsobilost-k-právům-a-povinnostem a owl:Class, owl:NamedIndividual,
-    z-sgov-pojem:typ-kvalitativní-vlastnosti, z-sgov-pojem:typ-vlastnosti;
-  rdfs:subClassOf z-sgov-pojem:vlastnost, [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:je-vlastností;
-      owl:someValuesFrom v-sgov-pojem:subjekt-práva
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:subjekt-práva;
-      owl:onProperty z-sgov-pojem:je-vlastností
-    ] .
+z-sgov-pojem:typ a owl:Class .
 
 z-sgov-pojem:je-ve-vztahu a owl:ObjectProperty .
 
@@ -376,399 +771,35 @@ z-sgov-pojem:má-vztažený-prvek-2 a owl:ObjectProperty;
 
 z-sgov-pojem:proměnný-prvek a owl:Class .
 
-v-sgov-pojem:geografický-název a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf v-sgov-pojem:lokalizace-popisem .
-
-v-sgov-pojem:lokalizace-popisem a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf v-sgov-pojem:lokalizace-prostorového-objektu .
-
-v-sgov-pojem:geometrie a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf v-sgov-pojem:lokalizace-prostorového-objektu .
-
-v-sgov-pojem:lokalizace-prostorového-objektu a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf v-sgov-pojem:prostorový-objekt .
-
-v-sgov-pojem:lokalizace-vyjádřená-prostorovým-objektem a owl:Class, owl:NamedIndividual,
-    z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf v-sgov-pojem:lokalizace-prostorového-objektu, v-sgov-pojem:prostorový-objekt .
-
-v-sgov-pojem:prostorový-objekt a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf z-sgov-pojem:objekt .
-
-v-sgov-pojem:má-definiční-lokalizaci a owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf v-sgov-pojem:má-lokalizaci .
-
-v-sgov-pojem:má-lokalizaci a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:prostorový-objekt;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
+v-sgov-pojem:spravuje a z-sgov-pojem:typ-vztahu;
+  rdfs:subClassOf [ a owl:Restriction;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom v-sgov-pojem:lokalizace-prostorového-objektu
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:lokalizace-prostorového-objektu;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
-      owl:someValuesFrom v-sgov-pojem:prostorový-objekt
-    ] .
-
-v-sgov-pojem:má-geometrii a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf v-sgov-pojem:má-lokalizaci, [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:geometrie;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom v-sgov-pojem:geometrie
-    ] .
-
-v-sgov-pojem:má-lokalizaci-názvem a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf v-sgov-pojem:má-lokalizaci-popisem, [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom v-sgov-pojem:geografický-název
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:geografický-název;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ] .
-
-v-sgov-pojem:má-lokalizaci-popisem a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf v-sgov-pojem:má-lokalizaci, [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:lokalizace-popisem;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom v-sgov-pojem:lokalizace-popisem
-    ] .
-
-v-sgov-pojem:má-platnost a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass v-sgov-pojem:datová-sada;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:datová-sada;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass z-sgov-pojem:časový-prvek;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom z-sgov-pojem:časový-prvek
-    ], [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass z-sgov-pojem:časový-prvek;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
       owl:someValuesFrom v-sgov-pojem:datová-sada
     ], [ a owl:Restriction;
-      owl:allValuesFrom z-sgov-pojem:časový-prvek;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass v-sgov-pojem:datová-sada;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
       owl:allValuesFrom v-sgov-pojem:datová-sada;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass z-sgov-pojem:časový-prvek;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ] .
-
-v-sgov-pojem:má-vztah-k-prostorovému-objektu a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf v-sgov-pojem:má-lokalizaci, [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:lokalizace-vyjádřená-prostorovým-objektem;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom v-sgov-pojem:lokalizace-vyjádřená-prostorovým-objektem
-    ] .
-
-v-sgov-pojem:popisuje a z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom v-sgov-pojem:popsaný-prvek
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:popsaný-prvek;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass v-sgov-pojem:položka;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:položka;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass v-sgov-pojem:popsaný-prvek;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass v-sgov-pojem:položka;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass v-sgov-pojem:popsaný-prvek;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
-      owl:someValuesFrom v-sgov-pojem:položka
-    ] .
-
-v-sgov-pojem:má-znění a owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom v-sgov-pojem:znění-právního-předpisu
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:znění-právního-předpisu;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
-      owl:someValuesFrom v-sgov-pojem:právní-předpis
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:právní-předpis;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ] .
-
-v-sgov-pojem:má-část-znění a owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:část-znění-právního-předpisu;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom v-sgov-pojem:část-znění-právního-předpisu
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:znění-právního-předpisu;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
-      owl:someValuesFrom v-sgov-pojem:znění-právního-předpisu
-    ] .
-
-v-sgov-pojem:novelizuje a owl:NamedIndividual, z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf z-sgov-pojem:vztah, [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:znění-právního-předpisu;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:novela-právního-předpisu;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom v-sgov-pojem:znění-právního-předpisu
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
-      owl:someValuesFrom v-sgov-pojem:novela-právního-předpisu
-    ] .
-
-v-sgov-pojem:název-právního-předpisu a owl:NamedIndividual, z-sgov-pojem:typ-vlastnosti;
-  rdfs:subClassOf z-sgov-pojem:vlastnost, [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:je-vlastností;
-      owl:someValuesFrom v-sgov-pojem:právní-předpis
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:právní-předpis;
-      owl:onProperty z-sgov-pojem:je-vlastností
-    ] .
-
-v-sgov-pojem:novela-právního-předpisu a owl:NamedIndividual, z-sgov-pojem:poddruh,
-    z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf v-sgov-pojem:znění-právního-předpisu .
-
-v-sgov-pojem:konsolidované-znění-právního-předpisu a owl:NamedIndividual, z-sgov-pojem:poddruh,
-    z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf v-sgov-pojem:znění-právního-předpisu .
-
-v-sgov-pojem:část-znění-právního-předpisu a owl:NamedIndividual, z-sgov-pojem:druh,
-    z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf v-sgov-pojem:kontextový-dokument .
-
-v-sgov-pojem:vyhlášené-znění-právního-předpisu a owl:NamedIndividual, z-sgov-pojem:poddruh,
-    z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf v-sgov-pojem:znění-právního-předpisu .
-
-v-sgov-pojem:znění-právního-předpisu a owl:NamedIndividual, z-sgov-pojem:druh, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf v-sgov-pojem:bezkontextový-dokument .
-
-v-sgov-pojem:část a owl:Class, owl:NamedIndividual, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf v-sgov-pojem:část-znění-právního-předpisu .
-
-v-sgov-pojem:jméno-právnické-osoby a owl:NamedIndividual, z-sgov-pojem:typ-vlastnosti;
-  rdfs:subClassOf z-sgov-pojem:vlastnost, [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:právnická-osoba;
-      owl:onProperty z-sgov-pojem:je-vlastností
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:je-vlastností;
-      owl:someValuesFrom v-sgov-pojem:právnická-osoba
-    ] .
-
-v-sgov-pojem:položka a z-sgov-pojem:kategorie, z-sgov-pojem:typ-objektu;
-  dcterms:source "";
-  rdfs:subClassOf z-sgov-pojem:pasivní-objekt, [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
-      owl:someValuesFrom v-sgov-pojem:má-čas-vytvoření
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:má-čas-vytvoření;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ] .
-
-v-sgov-pojem:kód-číselníku a z-sgov-pojem:typ-vlastnosti .
-
-v-sgov-pojem:akronym-číselníku a z-sgov-pojem:typ-vlastnosti .
-
-v-sgov-pojem:definice-číselníku a z-sgov-pojem:typ-vlastnosti .
-
-v-sgov-pojem:má-administrativní-platnost-číselníku a z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf v-sgov-pojem:má-platnost .
-
-v-sgov-pojem:má-administrativní-platnost-položky a z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf [ a owl:Restriction;
-      owl:allValuesFrom z-sgov-pojem:časový-prvek;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
-      owl:someValuesFrom v-sgov-pojem:položka
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom z-sgov-pojem:časový-prvek
-    ], [ a owl:Restriction;
-      owl:allValuesFrom z-sgov-pojem:časový-prvek;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:položka;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ] .
-
-v-sgov-pojem:pokrývá-oblast a z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom z-sgov-pojem:typ-objektu
-    ], [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass v-sgov-pojem:datová-sada;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass z-sgov-pojem:typ-objektu;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:allValuesFrom z-sgov-pojem:typ-objektu;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:datová-sada;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
     ], [ a owl:Restriction;
       owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
       owl:onClass v-sgov-pojem:datová-sada;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
+      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
     ], [ a owl:Restriction;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass z-sgov-pojem:typ-objektu;
+      owl:onClass v-sgov-pojem:datová-sada;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
     ], [ a owl:Restriction;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
-      owl:someValuesFrom v-sgov-pojem:datová-sada
-    ] .
-
-v-sgov-pojem:položka-evidenčního-systému a z-sgov-pojem:mixin-rolí, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf v-sgov-pojem:položka .
-
-v-sgov-pojem:digitální-objekt a z-sgov-pojem:kategorie, z-sgov-pojem:typ-objektu;
-  rdfs:subClassOf z-sgov-pojem:pasivní-objekt .
-
-v-sgov-pojem:má-čas-vytvoření a z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf [ a owl:Restriction;
-      owl:allValuesFrom z-sgov-pojem:časový-okamžik;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
+      owl:someValuesFrom v-sgov-pojem:informační-systém
     ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
-      owl:someValuesFrom z-sgov-pojem:proměnný-prvek
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom z-sgov-pojem:časový-okamžik
-    ], [ a owl:Restriction;
-      owl:allValuesFrom z-sgov-pojem:proměnný-prvek;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ] .
-
-v-sgov-pojem:má-čas-poslední-aktualizace a z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass z-sgov-pojem:časový-okamžik;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
-      owl:someValuesFrom z-sgov-pojem:proměnný-prvek
-    ], [ a owl:Restriction;
-      owl:allValuesFrom z-sgov-pojem:časový-okamžik;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom z-sgov-pojem:časový-okamžik
-    ], [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass z-sgov-pojem:časový-okamžik;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:allValuesFrom z-sgov-pojem:proměnný-prvek;
+      owl:allValuesFrom v-sgov-pojem:informační-systém;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
     ], [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass z-sgov-pojem:proměnný-prvek;
+      owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger;
+      owl:onClass v-sgov-pojem:informační-systém;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
     ], [ a owl:Restriction;
       owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass z-sgov-pojem:proměnný-prvek;
+      owl:onClass v-sgov-pojem:informační-systém;
       owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ] .
-
-v-sgov-pojem:eviduje-položku-evidenčního-systému a z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf v-sgov-pojem:eviduje, [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass v-sgov-pojem:evidenční-systém;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
-      owl:someValuesFrom v-sgov-pojem:evidenční-systém
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:evidenční-systém;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:maxQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass v-sgov-pojem:položka-evidenčního-systému;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:položka-evidenčního-systému;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom v-sgov-pojem:položka-evidenčního-systému
-    ], [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass v-sgov-pojem:evidenční-systém;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:minQualifiedCardinality "1"^^xsd:nonNegativeInteger;
-      owl:onClass v-sgov-pojem:položka-evidenčního-systému;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ] .
-
-v-sgov-pojem:má-přílohu a z-sgov-pojem:mixin, z-sgov-pojem:typ-vztahu;
-  rdfs:subClassOf [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:položka;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1
-    ], [ a owl:Restriction;
-      owl:allValuesFrom v-sgov-pojem:digitální-objekt;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-1;
-      owl:someValuesFrom v-sgov-pojem:položka
-    ], [ a owl:Restriction;
-      owl:onProperty z-sgov-pojem:má-vztažený-prvek-2;
-      owl:someValuesFrom v-sgov-pojem:digitální-objekt
     ] .
 
 skos:prefLabel rdfs:subPropertyOf rdfs:label .
-
-v-sgov-pojem:popsaný-prvek rdfs:subClassOf z-sgov-pojem:prvek .


### PR DESCRIPTION
Changed vocabularies: 
 - https://slovník.gov.cz/veřejný-sektor (kontext https://slovník.gov.cz/datový/pracovní-prostor/pojem/slovníkový-kontext/instance-1421630056)

-  fixes https://github.com/opendata-mvcr/ssp/issues/283
![image](https://user-images.githubusercontent.com/1140626/123974843-3c617b80-d9bd-11eb-944a-652df0eebdca.png)

-  fixes https://github.com/opendata-mvcr/ssp/issues/180
- removes "akronym číselníků", "kód číselníku", "definice číselníku" from V-SGoV (in favour of the same canonical terms in D-SGoV-číselníky)
- removes g-sgov-číselníky:číselník and rewires all subclasses to d-sgov-číselníky:číselník
![image](https://user-images.githubusercontent.com/1140626/123980078-8d736e80-d9c1-11eb-8a35-2d34000331dc.png)


